### PR TITLE
Adding streamifier to make buffer into a stream - Closes #2

### DIFF
--- a/jslib/index.js
+++ b/jslib/index.js
@@ -1,8 +1,10 @@
-var busboy, fs;
+var busboy, fs, streamifier;
 
 busboy = require('connect-busboy');
 
 fs = require('fs-extra');
+
+streamifier = require('streamifier');
 
 module.exports = function(options) {
   options = options || {};
@@ -37,7 +39,7 @@ module.exports = function(options) {
             mv: function(path, callback) {
               var fstream;
               fstream = fs.createWriteStream(path);
-              this.data.pipe(fstream);
+              streamifier.createReadStream(buf).pipe(fstream);
               fstream.on('error', function(error) {
                 return callback(error);
               });

--- a/package.json
+++ b/package.json
@@ -6,7 +6,8 @@
   "main": "./jslib/index",
   "dependencies": {
     "connect-busboy": "0.0.2",
-    "fs-extra": "^0.22.1"
+    "fs-extra": "^0.22.1",
+    "streamifier": "^0.1.1"
   },
   "engines": {
     "node": ">=0.8.0"
@@ -32,7 +33,6 @@
     "coffee-script": "^1.9.3",
     "gulp": "^3.9.0",
     "gulp-coffee": "^2.3.1",
-    "gulp-util": "^3.0.6",
-    "streamifier": "^0.1.1"
+    "gulp-util": "^3.0.6"
   }
 }

--- a/package.json
+++ b/package.json
@@ -32,6 +32,7 @@
     "coffee-script": "^1.9.3",
     "gulp": "^3.9.0",
     "gulp-coffee": "^2.3.1",
-    "gulp-util": "^3.0.6"
+    "gulp-util": "^3.0.6",
+    "streamifier": "^0.1.1"
   }
 }


### PR DESCRIPTION
Sorry I edited the js directly, but this should fix the this.data undefined.
When I tried to update the coffee file, I always got an unexpected indentation error when I ran `gulp coffee` after adding the following line `streamifier.createReadStream(buf).pipe(fstream)`