### PR TITLE
fix problem  in firefox with empty file upload

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -32,6 +32,14 @@ module.exports = function(options) {
                 file.on('end', function() {
                     if (!req.files)
                         req.files = {};
+                    
+                    
+                    // see: https://github.com/richardgirges/express-fileupload/issues/14
+                    // firefox uploads empty file in case of cache miss when f5ing page.
+                    // resulting in unexpected behavior. if there is no file data, the file is invalid.
+                    
+                    if(!buf.length) 
+                        return;
 
                     return req.files[fieldname] = {
                         name: filename,
@@ -50,6 +58,8 @@ module.exports = function(options) {
                             });
                         }
                     };
+                    
+                    
                 });
             });
 


### PR DESCRIPTION
closes #14 

code is simple, it just checks that the buffer isn't empty, and returns void if so. otherwise, it returns the file object as expected.