### PR TITLE
Support arrays of fields (similar to busboy 'autoFields' option)

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -16,7 +16,10 @@ module.exports = function(options) {
 
       req.busboy.on('field', function(fieldname, val, fieldnameTruncated, valTruncated, encoding, mimetype) {
         req.body = req.body || {};
-        req.body[fieldname] = val;
+        var prev = req.body[fieldname];
+        if (!prev) return req.body[fieldname] = val;
+        if (Array.isArray(prev)) return prev.push(val);
+        req.body[fieldname] = [prev, val];
       });
 
       req.busboy.on('file', function(fieldname, file, filename, encoding, mimetype) {


### PR DESCRIPTION
If a form has multiple fields with the same name only the value of the last field is returned in the form body. An array of values should be returned instead.