### PR TITLE
improve performance for large files

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -67,11 +67,11 @@ function processMultipart(options, req, res, next) {
 
   // Build req.files fields
   busboy.on('file', function(fieldname, file, filename, encoding, mime) {
-    let buf = new Buffer(0);
+    const buffers = [];
     let safeFileNameRegex = /[^\w-]/g;
 
     file.on('data', function(data) {
-      buf = Buffer.concat([buf, data]);
+      buffers.push(data);
 
       if (options.debug)
         return console.log('Uploading %s -> %s', fieldname, filename);
@@ -81,6 +81,7 @@ function processMultipart(options, req, res, next) {
       if (!req.files)
         req.files = {};
 
+      const buf = Buffer.concat(buffers);
       // see: https://github.com/richardgirges/express-fileupload/issues/14
       // firefox uploads empty file in case of cache miss when f5ing page.
       // resulting in unexpected behavior. if there is no file data, the file is invalid.


### PR DESCRIPTION
Using `buf = Buffer.concat([buf, data]);` on the data event copies the
data in a new larger buffer everytime. Instead, store the intermediate
small buffers in an array and concat only at the end.

Test with a 117MB file:
- before: 83.868 seconds
- after: 2.230 seconds