### PR TITLE
Add error handlers for parser errors

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -154,9 +154,13 @@ function processMultipart(options, req, res, next) {
           req.files[fieldname] = [req.files[fieldname], newFile];
       }
     });
+
+    file.on('error', next);
   });
 
   busboy.on('finish', next);
+
+  busboy.on('error', next);
 
   req.pipe(busboy);
 }


### PR DESCRIPTION
Currently there is an unhandled error event when syntactically incorrect multipart data is sent by the client which causes node.js to crash. This PR adds basic handlers that allow the node server to live on.

```
events.js:160
      throw er; // Unhandled 'error' event
      ^

Error: Part terminated early due to unexpected end of multipart data
    at /var/www/web/server/node_modules/dicer/lib/Dicer.js:65:36
    at _combinedTickCallback (internal/process/next_tick.js:67:7)
    at process._tickCallback (internal/process/next_tick.js:98:9)
```
