### PR TITLE
Temporary Directory

### DIFF
--- a/lib/index.js
+++ b/lib/index.js
@@ -178,7 +178,7 @@ function processMultipart(options, req, res, next) {
               });
             } else {
               fs.rename(tempFilePath, path, function (error) {
-                errorFunc(errorFunc);
+                errorFunc(error);
               })
             }
           }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 const Busboy = require('busboy');
 const fs = require('fs-extra');
 const { tmpdir } = require('os')
-const { join } = require('path')
+const { join, basename } = require('path')
 const { promisify } = require('util')
 const streamifier = require('streamifier');
 const ACCEPTABLE_MIME = /^(?:multipart\/.+)$/i;
@@ -177,6 +177,10 @@ async function processMultipart(options, req, res, next) {
               fstream.on('close', function() {
                 successFunc();
               });
+            } else {
+              promisify(fs.rename)(tempFilePath, path)
+                .then(successFunc)
+                .catch(errorFunc)
             }
           }
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -4,7 +4,6 @@ const Busboy = require('busboy');
 const fs = require('fs-extra');
 const { tmpdir } = require('os')
 const { join } = require('path')
-const { promisify } = require('util')
 const streamifier = require('streamifier');
 const ACCEPTABLE_MIME = /^(?:multipart\/.+)$/i;
 const UNACCEPTABLE_METHODS = [
@@ -178,9 +177,9 @@ function processMultipart(options, req, res, next) {
                 successFunc();
               });
             } else {
-              promisify(fs.rename)(tempFilePath, path)
-                .then(successFunc)
-                .catch(errorFunc);
+              fs.rename(tempFilePath, path, function (error) {
+                errorFunc(errorFunc);
+              })
             }
           }
         }

--- a/lib/index.js
+++ b/lib/index.js
@@ -2,7 +2,7 @@
 const Busboy = require('busboy');
 const fs = require('fs-extra');
 const { tmpdir } = require('os')
-const { join, basename } = require('path')
+const { join } = require('path')
 const { promisify } = require('util')
 const streamifier = require('streamifier');
 const ACCEPTABLE_MIME = /^(?:multipart\/.+)$/i;
@@ -78,7 +78,7 @@ async function processMultipart(options, req, res, next) {
     let safeFileNameRegex = /[^\w-]/g;
 
     file.on('data', function(data) {
-      if (tempFilePath) fs.appendFile(tempFilePath, data)
+      if (tempFilePath) fs.appendFileSync(tempFilePath, data)
       else buffers.push(data);
       if (options.debug) {
         return console.log('Uploading %s -> %s', fieldname, filename);

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,10 @@
 'use strict';
-
 const Busboy = require('busboy');
 const fs = require('fs-extra');
+const { tmpdir } = require('os')
+const { join } = require('path')
+const { promisify } = require('util')
 const streamifier = require('streamifier');
-
 const ACCEPTABLE_MIME = /^(?:multipart\/.+)$/i;
 const UNACCEPTABLE_METHODS = [
   'GET',
@@ -32,7 +33,7 @@ module.exports = function(options) {
  * @param  {Function} next    Express next method
  * @return {void}
  */
-function processMultipart(options, req, res, next) {
+async function processMultipart(options, req, res, next) {
   let busboyOptions = {};
   let busboy;
 
@@ -69,29 +70,34 @@ function processMultipart(options, req, res, next) {
   });
 
   // Build req.files fields
-  busboy.on('file', function(fieldname, file, filename, encoding, mime) {
+  busboy.on('file', async function(fieldname, file, filename, encoding, mime) {
+    let tempDirectory = options.diskCache ? await promisify(fs.mkdtemp)(join(tmpdir(), `${fieldname}_`)) : null
+    let tempFilePath = tempDirectory ? join(tempDirectory, filename) : null
+    console.log(tempDirectory)
     const buffers = [];
     let safeFileNameRegex = /[^\w-]/g;
 
     file.on('data', function(data) {
-      buffers.push(data);
-
+      if (tempFilePath) fs.appendFile(tempFilePath, data)
+      else buffers.push(data);
       if (options.debug) {
         return console.log('Uploading %s -> %s', fieldname, filename);
       }
     });
 
     file.on('end', function() {
+      var buf
       if (!req.files) {
         req.files = {};
       }
-
-      const buf = Buffer.concat(buffers);
-      // see: https://github.com/richardgirges/express-fileupload/issues/14
-      // firefox uploads empty file in case of cache miss when f5ing page.
-      // resulting in unexpected behavior. if there is no file data, the file is invalid.
-      if (!buf.length) {
-        return;
+      if (!tempFilePath)  {
+        buf = Buffer.concat(buffers);
+        // see: https://github.com/richardgirges/express-fileupload/issues/14
+        // firefox uploads empty file in case of cache miss when f5ing page.
+        // resulting in unexpected behavior. if there is no file data, the file is invalid.
+        if (!buf.length) {
+          return;
+        }
       }
 
       if (options.safeFileNames) {
@@ -131,7 +137,6 @@ function processMultipart(options, req, res, next) {
 
       let newFile = {
         name: filename,
-        data: buf,
         encoding: encoding,
         mimetype: mime,
         mv: function(path, callback) {
@@ -156,25 +161,31 @@ function processMultipart(options, req, res, next) {
           /**
            * Local function that moves the file to a different location on the filesystem
            * Takes two function arguments to make it compatible w/ Promise or Callback APIs
-           * @param {Function} successFunc 
-           * @param {Function} errorFunc 
+           * @param {Function} successFunc
+           * @param {Function} errorFunc
            */
           function doMove(successFunc, errorFunc) {
-            const fstream = fs.createWriteStream(path);
+            if (!tempFilePath) {
+              const fstream = fs.createWriteStream(path);
 
-            streamifier.createReadStream(buf).pipe(fstream);
+              streamifier.createReadStream(buf).pipe(fstream);
 
-            fstream.on('error', function(error) {
-              errorFunc(error);
-            });
+              fstream.on('error', function(error) {
+                errorFunc(error);
+              });
 
-            fstream.on('close', function() {
-              successFunc();
-            });
+              fstream.on('close', function() {
+                successFunc();
+              });
+            }
           }
         }
       };
-
+      if (tempFilePath) {
+        newFile.path = tempFilePath
+      } else {
+        newFile.data = buf
+      }
       // Non-array fields
       if (!req.files.hasOwnProperty(fieldname)) {
         req.files[fieldname] = newFile;

--- a/lib/index.js
+++ b/lib/index.js
@@ -73,7 +73,6 @@ async function processMultipart(options, req, res, next) {
   busboy.on('file', async function(fieldname, file, filename, encoding, mime) {
     let tempDirectory = options.diskCache ? await promisify(fs.mkdtemp)(join(tmpdir(), `${fieldname}_`)) : null
     let tempFilePath = tempDirectory ? join(tempDirectory, filename) : null
-    console.log(tempDirectory)
     const buffers = [];
     let safeFileNameRegex = /[^\w-]/g;
 

--- a/lib/index.js
+++ b/lib/index.js
@@ -34,7 +34,7 @@ module.exports = function(options) {
  * @param  {Function} next    Express next method
  * @return {void}
  */
-async function processMultipart(options, req, res, next) {
+function processMultipart(options, req, res, next) {
   let busboyOptions = {};
   let busboy;
 
@@ -71,8 +71,8 @@ async function processMultipart(options, req, res, next) {
   });
 
   // Build req.files fields
-  busboy.on('file', async function(fieldname, file, filename, encoding, mime) {
-    let tempDirectory = options.diskCache ? await promisify(fs.mkdtemp)(join(tmpdir(), `${fieldname}_`)) : null;
+  busboy.on('file', function(fieldname, file, filename, encoding, mime) {
+    let tempDirectory = options.diskCache ? fs.mkdtempSync(join(tmpdir(), `${fieldname}_`)) : null;
     let tempFilePath = tempDirectory ? join(tempDirectory, filename) : null;
     const buffers = [];
     let safeFileNameRegex = /[^\w-]/g;

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const Busboy = require('busboy');
 const fs = require('fs-extra');
 const { tmpdir } = require('os')
@@ -71,13 +72,13 @@ async function processMultipart(options, req, res, next) {
 
   // Build req.files fields
   busboy.on('file', async function(fieldname, file, filename, encoding, mime) {
-    let tempDirectory = options.diskCache ? await promisify(fs.mkdtemp)(join(tmpdir(), `${fieldname}_`)) : null
-    let tempFilePath = tempDirectory ? join(tempDirectory, filename) : null
+    let tempDirectory = options.diskCache ? await promisify(fs.mkdtemp)(join(tmpdir(), `${fieldname}_`)) : null;
+    let tempFilePath = tempDirectory ? join(tempDirectory, filename) : null;
     const buffers = [];
     let safeFileNameRegex = /[^\w-]/g;
 
     file.on('data', function(data) {
-      if (tempFilePath) fs.appendFileSync(tempFilePath, data)
+      if (tempFilePath) fs.appendFileSync(tempFilePath, data);
       else buffers.push(data);
       if (options.debug) {
         return console.log('Uploading %s -> %s', fieldname, filename);
@@ -85,7 +86,7 @@ async function processMultipart(options, req, res, next) {
     });
 
     file.on('end', function() {
-      var buf
+      var buf;
       if (!req.files) {
         req.files = {};
       }
@@ -179,15 +180,15 @@ async function processMultipart(options, req, res, next) {
             } else {
               promisify(fs.rename)(tempFilePath, path)
                 .then(successFunc)
-                .catch(errorFunc)
+                .catch(errorFunc);
             }
           }
         }
       };
       if (tempFilePath) {
-        newFile.path = tempFilePath
+        newFile.path = tempFilePath;
       } else {
-        newFile.data = buf
+        newFile.data = buf;
       }
       // Non-array fields
       if (!req.files.hasOwnProperty(fieldname)) {


### PR DESCRIPTION
Adds a boolean diskCache option to enable writing data to a temporary directory, resolving a buffer overflow issue when concatenation exceeds 2147483647 bytes. When enabled, the file path is returned in place of a buffer.