### PR TITLE
Reusable file object

### DIFF
--- a/lib/fileFactory.js
+++ b/lib/fileFactory.js
@@ -1,0 +1,55 @@
+'use strict';
+
+const fs = require('fs-extra');
+const streamifier = require('streamifier');
+const md5 = require('md5');
+
+module.exports = function(options) {
+  return {
+    name: options.name,
+    data: options.buffer,
+    encoding: options.encoding,
+    truncated: options.truncated,
+    mimetype: options.mimetype,
+    md5: md5(options.buffer),
+    mv: function(path, callback) {
+      // Callback is passed in, use the callback API
+      if (callback) {
+        doMove(
+          () => {
+            callback(null);
+          },
+          (error) => {
+            callback(error);
+          }
+        );
+
+      // Otherwise, return a promise
+      } else {
+        return new Promise((resolve, reject) => {
+          doMove(resolve, reject);
+        });
+      }
+
+      /**
+       * Local function that moves the file to a different location on the filesystem
+       * Takes two function arguments to make it compatible w/ Promise or Callback APIs
+       * @param {Function} successFunc
+       * @param {Function} errorFunc
+       */
+      function doMove(successFunc, errorFunc) {
+        const fstream = fs.createWriteStream(path);
+
+        streamifier.createReadStream(options.buffer).pipe(fstream);
+
+        fstream.on('error', function(error) {
+          errorFunc(error);
+        });
+
+        fstream.on('close', function() {
+          successFunc();
+        });
+      }
+    }
+  };
+};

--- a/lib/index.js
+++ b/lib/index.js
@@ -21,6 +21,8 @@ module.exports = function(options) {
   };
 };
 
+module.exports.fileFactory = fileFactory;
+
 /**
  * Processes multipart request
  * Builds a req.body object for fields

--- a/lib/index.js
+++ b/lib/index.js
@@ -1,9 +1,7 @@
 'use strict';
 
 const Busboy = require('busboy');
-const fs = require('fs-extra');
-const streamifier = require('streamifier');
-const md5 = require('md5');
+const fileFactory = require('./fileFactory');
 
 const ACCEPTABLE_MIME = /^(?:multipart\/.+)$/i;
 const UNACCEPTABLE_METHODS = [
@@ -137,53 +135,13 @@ function processMultipart(options, req, res, next) {
         filename = filename.replace(safeFileNameRegex, '').concat(extension);
       }
 
-      let newFile = {
+      const newFile = fileFactory({
         name: filename,
-        data: buf,
+        buffer: buf,
         encoding: encoding,
         truncated: file.truncated,
-        mimetype: mime,
-        md5: md5(buf),
-        mv: function(path, callback) {
-          // Callback is passed in, use the callback API
-          if (callback) {
-            doMove(
-              () => {
-                callback(null);
-              },
-              (error) => {
-                callback(error);
-              }
-            );
-
-          // Otherwise, return a promise
-          } else {
-            return new Promise((resolve, reject) => {
-              doMove(resolve, reject);
-            });
-          }
-
-          /**
-           * Local function that moves the file to a different location on the filesystem
-           * Takes two function arguments to make it compatible w/ Promise or Callback APIs
-           * @param {Function} successFunc
-           * @param {Function} errorFunc
-           */
-          function doMove(successFunc, errorFunc) {
-            const fstream = fs.createWriteStream(path);
-
-            streamifier.createReadStream(buf).pipe(fstream);
-
-            fstream.on('error', function(error) {
-              errorFunc(error);
-            });
-
-            fstream.on('close', function() {
-              successFunc();
-            });
-          }
-        }
-      };
+        mimetype: mime
+      });
 
       // Non-array fields
       if (!req.files.hasOwnProperty(fieldname)) {

--- a/test/fileFactory.spec.js
+++ b/test/fileFactory.spec.js
@@ -4,7 +4,7 @@ const assert = require('assert');
 const fs = require('fs');
 const md5 = require('md5');
 const path = require('path');
-const fileFactory = require('../lib/fileFactory');
+const fileFactory = require('../lib').fileFactory;
 const server = require('./server');
 
 const mockBuffer = fs.readFileSync(path.join(server.fileDir, 'basketball.png'));

--- a/test/fileFactory.spec.js
+++ b/test/fileFactory.spec.js
@@ -1,0 +1,78 @@
+'use strict';
+
+const assert = require('assert');
+const fs = require('fs');
+const md5 = require('md5');
+const path = require('path');
+const fileFactory = require('../lib/fileFactory');
+const server = require('./server');
+
+const mockBuffer = fs.readFileSync(path.join(server.fileDir, 'basketball.png'));
+
+describe('Test of the fileFactory factory', function() {
+  beforeEach(function() {
+    server.clearUploadsDir();
+  });
+
+  it('return a file object', function() {
+    assert.ok(fileFactory({
+      name: 'basketball.png',
+      buffer: mockBuffer
+    }));
+  });
+
+  describe('File object behavior', function() {
+    const file = fileFactory({
+      name: 'basketball.png',
+      buffer: mockBuffer
+    });
+    it('move the file to the specified folder', function(done) {
+      file.mv(path.join(server.uploadDir, 'basketball.png'), function(err) {
+        assert.ifError(err);
+        done();
+      });
+    });
+    it('reject the mv if the destination does not exists', function(done) {
+      file.mv(path.join(server.uploadDir, 'unknown', 'basketball.png'), function(err) {
+        assert.ok(err);
+        done();
+      });
+    });
+  });
+
+  describe('Properties', function() {
+    it('contains the name property', function() {
+      assert.equal(fileFactory({
+        name: 'basketball.png',
+        buffer: mockBuffer
+      }).name, 'basketball.png');
+    });
+    it('contains the data property', function() {
+      assert.ok(fileFactory({
+        name: 'basketball.png',
+        buffer: mockBuffer
+      }).data);
+    });
+    it('contains the encoding property', function() {
+      assert.equal(fileFactory({
+        name: 'basketball.png',
+        buffer: mockBuffer,
+        encoding: 'utf-8'
+      }).encoding, 'utf-8');
+    });
+    it('contains the mimetype property', function() {
+      assert.equal(fileFactory({
+        name: 'basketball.png',
+        buffer: mockBuffer,
+        mimetype: 'image/png'
+      }).mimetype, 'image/png');
+    });
+    it('contains the md5 property', function() {
+      const mockMd5 = md5(mockBuffer);
+      assert.equal(fileFactory({
+        name: 'basketball.png',
+        buffer: mockBuffer
+      }).md5, mockMd5);
+    });
+  });
+});

--- a/test/server.js
+++ b/test/server.js
@@ -1,4 +1,5 @@
 'use strict';
+
 const path = require('path');
 const fileDir = path.join(__dirname, 'files');
 const uploadDir = path.join(__dirname, 'uploads');


### PR DESCRIPTION
Hello there!

First of all: thank you for this project! Life & time saver.

I am using this middleware on several projects, and I have, on all of those project, the same problem:

> How can I correctly test my file uploading system?

The problem is:
I do not only upload files, but I also do some business transformation on them. As I try to keep everything as simple as possible: I just use your file object without decorator or anything else.

So, for the tests… it need many boilerplates or… a decorator…

This is why this pull request:

I would love to have a real FileObject / File or just a factory. I choose the factory option to keep this project also simple.

The steps are split on several commits. If you agree on the principe, I would like to talk about the last one: https://github.com/richardgirges/express-fileupload/commit/64ff2b5b7b6bea56349ffe4eb01cb1f4c572bd83

I've exposed the `fileFactory`, so people who want to use it can simply do:

```javascript
const fileFactory = require('express-fileupload').fileFactory;
```

If you just want to replace it by:

```javascript
const fileFactory = require('express-fileupload/lib/fileFactory');
```

Just ask.

To finish, as it is quite like a _low level_ functionality, I don't think it should be documented, people who want to test it can find it easily by looking at this repository.

Thank you!