### PR TITLE
[Bugfix] Pass options to File Factory

### DIFF
--- a/lib/processMultipart.js
+++ b/lib/processMultipart.js
@@ -121,7 +121,7 @@ module.exports = function processMultipart(options, req, res, next) {
         encoding: encoding,
         truncated: file.truncated,
         mimetype: mime
-      });
+      }, options);
 
       // Non-array fields
       if (!req.files.hasOwnProperty(fieldname)) {


### PR DESCRIPTION
If we don't pass them then for example the `mv` function can't use the `createParentPath` property.