### PR TITLE
tempFileDir use absolute path.

### DIFF
--- a/lib/tempFileHandler.js
+++ b/lib/tempFileHandler.js
@@ -19,7 +19,7 @@ module.exports.complete = function(){
 };
 
 module.exports.tempFileHandler = function(options, fieldname, filename) {
-  const dir = __dirname + (options.tempFileDir || '/tmp/');
+  const dir = options.tempFileDir || process.cwd() + '/tmp/';
 
   if (!fs.existsSync(dir)) {
     fs.mkdirSync(dir);


### PR DESCRIPTION
```
app.use(fileUpload({
  useTempFiles: true,
  tempFileDir: path.join(__dirname, 'upload_tmp')
}));
```
Error: ENOENT: no such file or directory, mkdir '/Users/linquan/xxx/node_modules/express-fileupload/lib/Users/linquan/xxx/upload_tmp'

so...
```
app.use(fileUpload({
  useTempFiles: true,
  tempFileDir: '/../../../../upload_tmp/'
}));
```
too ugly