### PR TITLE
 move mv method local funcs outside of the factory

### DIFF
--- a/lib/fileFactory.js
+++ b/lib/fileFactory.js
@@ -7,11 +7,11 @@ const md5 = require('md5');
 
 /**
  * Creates a folder for file specified in the path variable
- * @param {Object} options
- * @parem {String} path
+ * @param {Object} fileUploadOptions
+ * @param {String} filePath
  */
-const checkAndMakeDir = function(options, filePath){
-  if (options && options.createParentPath) {
+const checkAndMakeDir = function(fileUploadOptions, filePath){
+  if (fileUploadOptions && fileUploadOptions.createParentPath) {
     const parentPath = path.dirname(filePath);
     if (!fs.existsSync(parentPath)) {
       fs.mkdirSync(parentPath);
@@ -24,7 +24,6 @@ const checkAndMakeDir = function(options, filePath){
  * which takes two function arguments to make it compatible w/ Promise or Callback APIs
  * @param {String} filePath
  * @param {Object} options
- * @param {Object} fileUploadOptions
  */
 const moveFromTemp = function(filePath, options) {
   return function(successFunc, errorFunc){
@@ -43,7 +42,6 @@ const moveFromTemp = function(filePath, options) {
  * which takes two function arguments to make it compatible w/ Promise or Callback APIs
  * @param {String} filePath
  * @param {Object} options
- * @param {Object} fileUploadOptions
  */
 function moveFromBuffer(filePath, options) {
   return function(successFunc, errorFunc){

--- a/lib/fileFactory.js
+++ b/lib/fileFactory.js
@@ -17,7 +17,7 @@ const checkAndMakeDir = function(fileUploadOptions, filePath){
       fs.mkdirSync(parentPath);
     }
   }
-}
+};
 
 /**
  * Returns Local function that moves the file to a different location on the filesystem
@@ -35,7 +35,7 @@ const moveFromTemp = function(filePath, options) {
       }
     });
   };
-}
+};
 
 /**
  * Returns Local function that moves the file from buffer to a different location on the filesystem
@@ -43,7 +43,7 @@ const moveFromTemp = function(filePath, options) {
  * @param {String} filePath
  * @param {Object} options
  */
-function moveFromBuffer(filePath, options) {
+const moveFromBuffer = function(filePath, options) {
   return function(successFunc, errorFunc){
     const fstream = fs.createWriteStream(filePath);
     streamifier.createReadStream(options.buffer).pipe(fstream);
@@ -54,7 +54,7 @@ function moveFromBuffer(filePath, options) {
       successFunc();
     });
   };
-}
+};
 
 module.exports = function(options, fileUploadOptions = null) {
   return {

--- a/lib/fileFactory.js
+++ b/lib/fileFactory.js
@@ -8,7 +8,7 @@ const md5 = require('md5');
 /**
  * Returns true if argument is function.
  */
-const isFunc = func => return func && func.constructor && func.call && func.apply;
+const isFunc = func => func && func.constructor && func.call && func.apply;
 
 /**
  * Creates a folder for file specified in the path variable

--- a/lib/fileFactory.js
+++ b/lib/fileFactory.js
@@ -5,8 +5,61 @@ const path = require('path');
 const streamifier = require('streamifier');
 const md5 = require('md5');
 
+/**
+ * Creates a folder for file specified in the path variable
+ * @param {Object} options
+ * @parem {String} path
+ */
+const checkAndMakeDir = function(options, filePath){
+  if (options && options.createParentPath) {
+    const parentPath = path.dirname(filePath);
+    if (!fs.existsSync(parentPath)) {
+      fs.mkdirSync(parentPath);
+    }
+  }
+}
+
+/**
+ * Returns Local function that moves the file to a different location on the filesystem
+ * which takes two function arguments to make it compatible w/ Promise or Callback APIs
+ * @param {String} filePath
+ * @param {Object} options
+ * @param {Object} fileUploadOptions
+ */
+const moveFromTemp = function(filePath, options) {
+  return function(successFunc, errorFunc){
+    fs.rename(options.tempFilePath, filePath, function(err){
+      if (err) {
+        errorFunc(err);
+      } else {
+        successFunc();
+      }
+    });
+  };
+}
+
+/**
+ * Returns Local function that moves the file from buffer to a different location on the filesystem
+ * which takes two function arguments to make it compatible w/ Promise or Callback APIs
+ * @param {String} filePath
+ * @param {Object} options
+ * @param {Object} fileUploadOptions
+ */
+function moveFromBuffer(filePath, options) {
+  return function(successFunc, errorFunc){
+    const fstream = fs.createWriteStream(filePath);
+    streamifier.createReadStream(options.buffer).pipe(fstream);
+    fstream.on('error', function(error) {
+      errorFunc(error);
+    });
+    fstream.on('close', function() {
+      successFunc();
+    });
+  };
+}
+
 module.exports = function(options, fileUploadOptions = null) {
-  const output = {
+  return {
     name: options.name,
     data: options.buffer,
     size: options.size,
@@ -16,82 +69,28 @@ module.exports = function(options, fileUploadOptions = null) {
     mimetype: options.mimetype,
     md5: () => md5(options.buffer),
     mv: function(filePath, callback) {
+      // Determine propper move function.
+      let move = (options.buffer.length && !options.tempFilePath)
+        ? moveFromBuffer(filePath, options)
+        : moveFromTemp(filePath, options);
+      // Create a folder for file.
+      checkAndMakeDir(fileUploadOptions, filePath);
       // Callback is passed in, use the callback API
-      if (callback) {
-        if (options.buffer.length && !options.tempFilePath) {
-          moveFromBuffer(
-            () => {
-              callback(null);
-            },
-            error => {
-              callback(error);
-            }
-          );
-        } else {
-          moveFromTemp(
-            () => {
-              callback(null);
-            },
-            error => {
-              callback(error);
-            }
-          );
-        }
-
+      if (callback && callback.constructor && callback.call && callback.apply) {
+        move(
+          () => {
+            callback(null);
+          },
+          error => {
+            callback(error);
+          }
+        );
         // Otherwise, return a promise
       } else {
         return new Promise((resolve, reject) => {
-          if (options.buffer) {
-            moveFromBuffer(resolve, reject);
-          } else {
-            moveFromTemp(resolve, reject);
-          }
-        });
-      }
-
-      function checkAndMakeDir(){
-        if (fileUploadOptions && fileUploadOptions.createParentPath) {
-          const parentPath = path.dirname(filePath);
-          if (!fs.existsSync(parentPath)) {
-            fs.mkdirSync(parentPath);
-          }
-        }
-      }
-
-      /**
-       * Local function that moves the file to a different location on the filesystem
-       * Takes two function arguments to make it compatible w/ Promise or Callback APIs
-       * @param {Function} successFunc
-       * @param {Function} errorFunc
-       */
-      function moveFromTemp(successFunc, errorFunc) {
-        checkAndMakeDir();
-        fs.rename(options.tempFilePath, filePath, function(err){
-          if (err) {
-            errorFunc(err);
-          } else {
-            successFunc();
-          }
-        });
-      }
-
-      function moveFromBuffer(successFunc, errorFunc) {
-        checkAndMakeDir();
-
-        const fstream = fs.createWriteStream(filePath);
-
-        streamifier.createReadStream(options.buffer).pipe(fstream);
-
-        fstream.on('error', function(error) {
-          errorFunc(error);
-        });
-
-        fstream.on('close', function() {
-          successFunc();
+          move(resolve, reject);
         });
       }
     }
   };
-
-  return output;
 };

--- a/lib/fileFactory.js
+++ b/lib/fileFactory.js
@@ -6,6 +6,11 @@ const streamifier = require('streamifier');
 const md5 = require('md5');
 
 /**
+ * Returns true if argument is function.
+ */
+const isFunc = func => return func && func.constructor && func.call && func.apply;
+
+/**
  * Creates a folder for file specified in the path variable
  * @param {Object} fileUploadOptions
  * @param {String} filePath
@@ -27,6 +32,8 @@ const checkAndMakeDir = function(fileUploadOptions, filePath){
  */
 const moveFromTemp = function(filePath, options) {
   return function(successFunc, errorFunc){
+    // Set errorFunc to the same value as successFunc for callback mode.
+    errorFunc = isFunc(errorFunc) ? errorFunc : successFunc;
     fs.rename(options.tempFilePath, filePath, function(err){
       if (err) {
         errorFunc(err);
@@ -45,6 +52,8 @@ const moveFromTemp = function(filePath, options) {
  */
 const moveFromBuffer = function(filePath, options) {
   return function(successFunc, errorFunc){
+    // Set errorFunc to the same value as successFunc for callback mode.
+    errorFunc = isFunc(errorFunc) ? errorFunc : successFunc;
     const fstream = fs.createWriteStream(filePath);
     streamifier.createReadStream(options.buffer).pipe(fstream);
     fstream.on('error', function(error) {
@@ -68,27 +77,15 @@ module.exports = function(options, fileUploadOptions = null) {
     md5: () => md5(options.buffer),
     mv: function(filePath, callback) {
       // Determine propper move function.
-      let move = (options.buffer.length && !options.tempFilePath)
+      let moveFunc = (options.buffer.length && !options.tempFilePath)
         ? moveFromBuffer(filePath, options)
         : moveFromTemp(filePath, options);
       // Create a folder for file.
       checkAndMakeDir(fileUploadOptions, filePath);
-      // Callback is passed in, use the callback API
-      if (callback && callback.constructor && callback.call && callback.apply) {
-        move(
-          () => {
-            callback(null);
-          },
-          error => {
-            callback(error);
-          }
-        );
-        // Otherwise, return a promise
-      } else {
-        return new Promise((resolve, reject) => {
-          move(resolve, reject);
-        });
-      }
+      // If callback is passed in, use the callback API, otherwise return a promise.
+      return isFunc(callback)
+        ? moveFunc(callback)
+        : new Promise((resolve, reject) => moveFunc(resolve, reject));
     }
   };
 };


### PR DESCRIPTION
Moved 'mv' method local functions outside of the factory.
Added some comments.
Now in mv method we have one entry point for checking upload type(into memory or into a temporary file) instead of checking it two times for callback and promise cases.
Added check if callback is a function.