### PR TITLE
add functions to parse file names

### DIFF
--- a/lib/processMultipart.js
+++ b/lib/processMultipart.js
@@ -3,7 +3,10 @@ const fileFactory = require('./fileFactory');
 const memHandler = require('./memHandler');
 const tempFileHandler = require('./tempFileHandler');
 const processNested = require('./processNested');
-const {buildOptions} = require('./utilities');
+const {
+  buildOptions,
+  parseFileName
+} = require('./utilities');
 
 /**
  * Processes multipart request
@@ -68,51 +71,9 @@ module.exports = function processMultipart(options, req, res, next) {
         return;
       }
 
-      if (options.safeFileNames) {
-        let safeFileNameRegex = /[^\w-]/g;
-        let maxExtensionLength = 3;
-        let extension = '';
-
-        if (typeof options.safeFileNames === 'object') {
-          safeFileNameRegex = options.safeFileNames;
-        }
-
-        maxExtensionLength = parseInt(options.preserveExtension);
-        if (options.preserveExtension || maxExtensionLength === 0) {
-          if (isNaN(maxExtensionLength)) {
-            maxExtensionLength = 3;
-          } else {
-            maxExtensionLength = Math.abs(maxExtensionLength);
-          }
-
-          let filenameParts = filename.split('.');
-          let filenamePartsLen = filenameParts.length;
-          if (filenamePartsLen > 1) {
-            extension = filenameParts.pop();
-
-            if (
-              extension.length > maxExtensionLength &&
-              maxExtensionLength > 0
-            ) {
-              filenameParts[filenameParts.length - 1] +=
-                '.' +
-                extension.substr(0, extension.length - maxExtensionLength);
-              extension = extension.substr(-maxExtensionLength);
-            }
-
-            extension = maxExtensionLength
-              ? '.' + extension.replace(safeFileNameRegex, '')
-              : '';
-            filename = filenameParts.join('.');
-          }
-        }
-
-        filename = filename.replace(safeFileNameRegex, '').concat(extension);
-      }
-
       const newFile = fileFactory(
         {
-          name: filename,
+          name: parseFileName(options, filename),
           buffer,
           tempFilePath: getFilePath(),
           size: getFileSize(),

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -164,20 +164,20 @@ const parseFileNameExtension = (preserveExtension, fileName) => {
 
 /**
  * Parse file name and extension.
- * @param options {Object} - middleware options.
+ * @param opts {Object}     - middleware options.
  * @param fileName {String} - Uploaded file name.
  * @returns {String}
  */
-const parseFileName = (options, fileName) => {
-  if (!options.safeFileNames) {
+const parseFileName = (opts, fileName) => {
+  if (!opts.safeFileNames) {
     return fileName;
   }
   // Set regular expression for the file name.
-  let safeNameRegex = typeof options.safeFileNames === 'object' && options.safeFileNames instanceof RegExp
-    ? options.safeFileNames
+  let safeNameRegex = typeof opts.safeFileNames === 'object' && opts.safeFileNames instanceof RegExp
+    ? opts.safeFileNames
     : SAFE_FILE_NAME_REGEX;
   // Parse file name extension.
-  let {name, extension} = parseFileNameExtension(options.preserveExtension, fileName);
+  let {name, extension} = parseFileNameExtension(opts.preserveExtension, fileName);
   if (extension.length) extension = '.' + extension.replace(safeNameRegex, '');
 
   return name.replace(safeNameRegex, '').concat(extension);

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -4,6 +4,10 @@ const fs = require('fs');
 const path = require('path');
 const Readable = require('stream').Readable;
 
+//Parameters for safe file name parsing
+const SAFE_FILE_NAME_REGEX = /[^\w-]/g;
+const MAX_EXTENSION_LENGTH = 3;
+
 //Parameters which used to generate unique temporary file names:
 const TEMP_COUNTER_MAX = 65536;
 const TEMP_PREFIX = 'tmp';
@@ -120,6 +124,65 @@ const saveBufferToFile = function(buffer, filePath, callback){
   readStream.pipe(fstream);
 };
 
+/**
+ * Parses filename and extension and returns object {name, extension}.
+ * @param preserveExtension {Boolean, Integer} - true/false or number of characters for extension.
+ * @param fileName {String}                    - file name to parse.
+ * @returns {Object}                           - {name, extension}.
+ */
+const parseFileNameExtension = (preserveExtension, fileName) => {
+  let preserveExtensionLengh = parseInt(preserveExtension);
+  let result = {name: fileName, extension: ''};
+  if (!preserveExtension && preserveExtensionLengh !== 0){
+    return result;
+  }
+  // Define maximum extension length
+  let maxExtLength = isNaN(preserveExtensionLengh)
+    ? MAX_EXTENSION_LENGTH
+    : Math.abs(preserveExtensionLengh);
+
+  let nameParts = fileName.split('.');
+  if (nameParts.length < 2) {
+    return result;
+  }
+  
+  let extension = nameParts.pop();
+  if (
+    extension.length > maxExtLength &&
+    maxExtLength > 0
+  ) {
+    nameParts[nameParts.length - 1] +=
+      '.' +
+      extension.substr(0, extension.length - maxExtLength);
+    extension = extension.substr(-maxExtLength);
+  }
+
+  result.extension = maxExtLength ? extension : '';
+  result.name = nameParts.join('.');
+  return result;
+};
+
+/**
+ * Parse file name and extension.
+ * @param options {Object} - middleware options.
+ * @param fileName {String} - Uploaded file name.
+ * @returns {String}
+ */
+const parseFileName = (options, fileName) => {
+  if (!options.safeFileNames) {
+    return fileName;
+  }
+  // Set regular expression for the file name.
+  let safeNameRegex = typeof options.safeFileNames === 'object' && options.safeFileNames instanceof RegExp
+    ? options.safeFileNames
+    : SAFE_FILE_NAME_REGEX;
+  // Parse file name extension.
+  let {name, extension} = parseFileNameExtension(options.preserveExtension, fileName);
+  if (extension.length) extension = '.' + extension.replace(safeNameRegex, '');
+
+  return name.replace(safeNameRegex, '').concat(extension);
+};
+
 module.exports = {
   debugLog,
   isFunc,
@@ -127,5 +190,6 @@ module.exports = {
   checkAndMakeDir,
   copyFile,
   saveBufferToFile,
+  parseFileName,
   getTempFilename
 };

--- a/test/utilities.spec.js
+++ b/test/utilities.spec.js
@@ -122,7 +122,7 @@ describe('Test of the utilities functions', function() {
       });
 
     it(
-      'Strips away all non-alphanumeric chars when enabled and preserveExtension: true for a name without dot characters',
+      'Strips away all non-alphanumeric chars when enabled and preserveExtension: true for a name without dots',
       () => {
         const opts = {safeFileNames: true, preserveExtension: true};
         const name = 'my$Invalid#fileName';

--- a/test/utilities.spec.js
+++ b/test/utilities.spec.js
@@ -111,23 +111,25 @@ describe('Test of the utilities functions', function() {
       assert.equal(result, expected);
     });
 
-    it('Strips away all non-alphanumeric characters (excluding hyphens/underscores) when enabled.', () => {
-      const opts = {safeFileNames: true};
-      const name = 'my$Invalid#fileName.png123';
-      const expected = 'myInvalidfileNamepng123';
-      let result = parseFileName(opts, name);
-      assert.equal(result, expected);
-    });
+    it(
+      'Strips away all non-alphanumeric characters (excluding hyphens/underscores) when enabled.',
+      () => {
+        const opts = {safeFileNames: true};
+        const name = 'my$Invalid#fileName.png123';
+        const expected = 'myInvalidfileNamepng123';
+        let result = parseFileName(opts, name);
+        assert.equal(result, expected);
+      });
 
     it(
-    'Strips away all non-alphanumeric characters when enabled for a name which doesnt contain dots characters and preserveExtension: true.',
-    () => {
-      const opts = {safeFileNames: true, preserveExtension: true};
-      const name = 'my$Invalid#fileName';
-      const expected = 'myInvalidfileName';
-      let result = parseFileName(opts, name);
-      assert.equal(result, expected);
-    });
+      'Strips away all non-alphanumeric characters when enabled for a name which doesnt contain dots characters and preserveExtension: true.',
+      () => {
+        const opts = {safeFileNames: true, preserveExtension: true};
+        const name = 'my$Invalid#fileName';
+        const expected = 'myInvalidfileName';
+        let result = parseFileName(opts, name);
+        assert.equal(result, expected);
+      });
 
     it('Accepts a regex for stripping (decidedly) "invalid" characters from filename.', () => {
       const opts = {safeFileNames: /[$#]/g};
@@ -137,7 +139,9 @@ describe('Test of the utilities functions', function() {
       assert.equal(result, expected);
     });
 
-    it('Returns correct filename if name contains several dot characters and preserveExtension: true.', () => {
+    it(
+      'Returns correct filename if name contains several dot characters and preserveExtension: true.',
+      () => {
       const opts = {safeFileNames: true, preserveExtension: true};
       const name = 'basket.ball.png';
       const expected = 'basketball.png';

--- a/test/utilities.spec.js
+++ b/test/utilities.spec.js
@@ -122,7 +122,7 @@ describe('Test of the utilities functions', function() {
       });
 
     it(
-      'Strips away all non-alphanumeric chars when enabled and preserveExtension: true for a name without dots',
+      'Strips away all non-alphanumeric chars when preserveExtension: true for a name without dots',
       () => {
         const opts = {safeFileNames: true, preserveExtension: true};
         const name = 'my$Invalid#fileName';

--- a/test/utilities.spec.js
+++ b/test/utilities.spec.js
@@ -122,7 +122,7 @@ describe('Test of the utilities functions', function() {
       });
 
     it(
-      'Strips away all non-alphanumeric chars when enabled for a name which doesnt contain dots characters and preserveExtension: true.',
+      'Strips away all non-alphanumeric chars when enabled and preserveExtension: true for a name without dot characters',
       () => {
         const opts = {safeFileNames: true, preserveExtension: true};
         const name = 'my$Invalid#fileName';

--- a/test/utilities.spec.js
+++ b/test/utilities.spec.js
@@ -122,7 +122,7 @@ describe('Test of the utilities functions', function() {
       });
 
     it(
-      'Strips away all non-alphanumeric characters when enabled for a name which doesnt contain dots characters and preserveExtension: true.',
+      'Strips away all non-alphanumeric chars when enabled for a name which doesnt contain dots characters and preserveExtension: true.',
       () => {
         const opts = {safeFileNames: true, preserveExtension: true};
         const name = 'my$Invalid#fileName';
@@ -140,14 +140,14 @@ describe('Test of the utilities functions', function() {
     });
 
     it(
-      'Returns correct filename if name contains several dot characters and preserveExtension: true.',
+      'Returns correct filename if name contains dots characters and preserveExtension: true.',
       () => {
-      const opts = {safeFileNames: true, preserveExtension: true};
-      const name = 'basket.ball.png';
-      const expected = 'basketball.png';
-      let result = parseFileName(opts, name);
-      assert.equal(result, expected);
-    });
+        const opts = {safeFileNames: true, preserveExtension: true};
+        const name = 'basket.ball.png';
+        const expected = 'basketball.png';
+        let result = parseFileName(opts, name);
+        assert.equal(result, expected);
+      });
 
   });
   //buildOptions tests

--- a/test/utilities.spec.js
+++ b/test/utilities.spec.js
@@ -15,7 +15,8 @@ const {
   buildOptions,
   checkAndMakeDir,
   copyFile,
-  saveBufferToFile
+  saveBufferToFile,
+  parseFileName
 } = require('../lib/utilities.js');
 
 
@@ -96,6 +97,52 @@ describe('Test of the utilities functions', function() {
       }
 
       assert.equal(errCounter, 0);
+    });
+
+  });
+  //parseFileName
+  describe('Test parseFileName function', () => {
+
+    it('Does nothing to your filename when disabled.', () => {
+      const opts = {safeFileNames: false};
+      const name = 'my$Invalid#fileName.png123';
+      const expected = 'my$Invalid#fileName.png123';
+      let result = parseFileName(opts, name);
+      assert.equal(result, expected);
+    });
+
+    it('Strips away all non-alphanumeric characters (excluding hyphens/underscores) when enabled.', () => {
+      const opts = {safeFileNames: true};
+      const name = 'my$Invalid#fileName.png123';
+      const expected = 'myInvalidfileNamepng123';
+      let result = parseFileName(opts, name);
+      assert.equal(result, expected);
+    });
+
+    it(
+    'Strips away all non-alphanumeric characters when enabled for a name which doesnt contain dots characters and preserveExtension: true.',
+    () => {
+      const opts = {safeFileNames: true, preserveExtension: true};
+      const name = 'my$Invalid#fileName';
+      const expected = 'myInvalidfileName';
+      let result = parseFileName(opts, name);
+      assert.equal(result, expected);
+    });
+
+    it('Accepts a regex for stripping (decidedly) "invalid" characters from filename.', () => {
+      const opts = {safeFileNames: /[$#]/g};
+      const name = 'my$Invalid#fileName.png123';
+      const expected = 'myInvalidfileName.png123';
+      let result = parseFileName(opts, name);
+      assert.equal(result, expected);
+    });
+
+    it('Returns correct filename if name contains several dot characters and preserveExtension: true.', () => {
+      const opts = {safeFileNames: true, preserveExtension: true};
+      const name = 'basket.ball.png';
+      const expected = 'basketball.png';
+      let result = parseFileName(opts, name);
+      assert.equal(result, expected);
     });
 
   });


### PR DESCRIPTION
Move save file names functionality to the separate functions parseFileName and parseFileNameExtension.
That made processMultipart.js code cleaner and also usefull for testing.