### PR TITLE
Anchancements for isEligibleRequest and fileFactory

### DIFF
--- a/lib/fileFactory.js
+++ b/lib/fileFactory.js
@@ -34,7 +34,13 @@ const moveFromBuffer = (filePath, options) => {
   };
 };
 
-module.exports = (options, fileUploadOptions = null) => {
+module.exports = (options, fileUploadOptions = {}) => {
+  // see: https://github.com/richardgirges/express-fileupload/issues/14
+  // firefox uploads empty file in case of cache miss when f5ing page.
+  // resulting in unexpected behavior. if there is no file data, the file is invalid.
+  if (!fileUploadOptions.useTempFiles && !options.buffer.length) return;
+  
+  // Create and return file object.
   return {
     name: options.name,
     data: options.buffer,

--- a/lib/isEligibleRequest.js
+++ b/lib/isEligibleRequest.js
@@ -1,44 +1,34 @@
-const ACCEPTABLE_CONTENT_TYPE = /^(?:multipart\/.+)$/i;
-const UNACCEPTABLE_METHODS = [
-  'GET',
-  'HEAD'
-];
+const ACCEPTABLE_CONTENT_TYPE = /^(multipart\/.+);(.*)$/i;
+const UNACCEPTABLE_METHODS = ['GET', 'HEAD'];
 
 /**
- * Ensures that the request in question is eligible for file uploads
- * @param {Object} req Express req object
+ * Ensures the request contains a content body
+ * @param  {Object}  req Express req object
+ * @returns {Boolean}
  */
-module.exports = function(req) {
-  return hasBody(req) && hasAcceptableMethod(req) && hasAcceptableContentType(req);
+const hasBody = (req) => {
+  return ('transfer-encoding' in req.headers) ||
+    ('content-length' in req.headers && req.headers['content-length'] !== '0');
 };
 
 /**
  * Ensures the request is not using a non-compliant multipart method
  * such as GET or HEAD
  * @param  {Object}  req Express req object
- * @return {Boolean}
+ * @returns {Boolean}
  */
-function hasAcceptableMethod(req) {
-  return (UNACCEPTABLE_METHODS.indexOf(req.method) < 0);
-}
+const hasAcceptableMethod = req => !UNACCEPTABLE_METHODS.includes(req.method);
 
 /**
  * Ensures that only multipart requests are processed by express-fileupload
  * @param  {Object}  req Express req object
- * @return {Boolean}
+ * @returns {Boolean}
  */
-function hasAcceptableContentType(req) {
-  let str = (req.headers['content-type'] || '').split(';')[0];
-
-  return ACCEPTABLE_CONTENT_TYPE.test(str);
-}
+const hasAcceptableContentType = req => ACCEPTABLE_CONTENT_TYPE.test(req.headers['content-type']);
 
 /**
- * Ensures the request contains a content body
- * @param  {Object}  req Express req object
- * @return {Boolean}
+ * Ensures that the request in question is eligible for file uploads
+ * @param {Object} req Express req object
+ * @returns {Boolean}
  */
-function hasBody(req) {
-  return ('transfer-encoding' in req.headers) ||
-    ('content-length' in req.headers && req.headers['content-length'] !== '0');
-}
+module.exports = req => hasBody(req) && hasAcceptableMethod(req) && hasAcceptableContentType(req);

--- a/lib/processMultipart.js
+++ b/lib/processMultipart.js
@@ -46,19 +46,11 @@ module.exports = (options, req, res, next) => {
     file.on('data', dataHandler);
 
     file.on('end', () => {
-      const buffer = complete(filename);
-      // see: https://github.com/richardgirges/express-fileupload/issues/14
-      // firefox uploads empty file in case of cache miss when f5ing page.
-      // resulting in unexpected behavior. if there is no file data, the file is invalid.
-      if (!buffer.length && !options.useTempFiles) {
-        return;
-      }
-
       // Add file instance to the req.files
       req.files = buildFields(req.files, fieldname, fileFactory(
         {
+          buffer: complete(),
           name: parseFileName(options, filename),
-          buffer,
           tempFilePath: getFilePath(),
           size: getFileSize(),
           hash: getHash(),
@@ -69,7 +61,7 @@ module.exports = (options, req, res, next) => {
         options
       ));
     });
-
+    
     file.on('error', cleanup, next);
   });
 

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -85,6 +85,10 @@ const buildOptions = function(){
  * @returns {Object}
  */
 const buildFields = (instance, field, value) => {
+  //Do nothing if value is not set.
+  if (value === null || value === undefined){
+    return instance;
+  }
   instance = instance || {};
   // Non-array fields
   if (!instance[field]) {

--- a/test/fileFactory.spec.js
+++ b/test/fileFactory.spec.js
@@ -24,6 +24,15 @@ describe('Test of the fileFactory factory', function() {
     }));
   });
 
+  it('return void if buffer is empty and useTempFiles is false.', function() {
+    assert.equal(fileFactory({
+      name: 'basketball.png',
+      buffer: Buffer.concat([])
+    },{
+      useTempFiles: false
+    }), null);
+  });
+
   describe('Properties', function() {
     it('contains the name property', function() {
       assert.equal(fileFactory({

--- a/test/multipartUploads.spec.js
+++ b/test/multipartUploads.spec.js
@@ -9,16 +9,18 @@ const clearUploadsDir = server.clearUploadsDir;
 const fileDir = server.fileDir;
 const uploadDir = server.uploadDir;
 
-const mockFiles = [
-  'car.png',
-  'tree.png',
-  'basketball.png'
-];
+const mockFiles = ['car.png', 'tree.png', 'basketball.png'];
 
 let mockUser = {
   firstName: 'Joe',
   lastName: 'Schmo',
   email: 'joe@mailinator.com'
+};
+
+// Reset response body.uploadDir/uploadPath for testing.
+const resetBodyUploadData = (res)=>{
+  res.body.uploadDir = '';
+  res.body.uploadPath = '';
 };
 
 describe('Test Directory Cleaning Method', function() {
@@ -47,10 +49,7 @@ describe('Test Single File Upload', function() {
       request(app)
         .post('/upload/single')
         .attach('testFile', filePath)
-        .expect((res)=>{
-          res.body.uploadDir = '';
-          res.body.uploadPath = '';
-        })
+        .expect(resetBodyUploadData)
         .expect(200, {
           name: fileName,
           md5: fileHash,
@@ -79,10 +78,7 @@ describe('Test Single File Upload', function() {
       request(app)
         .post('/upload/single')
         .attach('testFile', filePath)
-        .expect((res)=>{
-          res.body.uploadDir = '';
-          res.body.uploadPath = '';
-        })
+        .expect(resetBodyUploadData)
         .expect(200, {
           name: fileName,
           md5: fileHash,
@@ -146,10 +142,7 @@ describe('Test Single File Upload w/ .mv()', function() {
       request(app)
         .post('/upload/single')
         .attach('testFile', filePath)
-        .expect((res)=>{
-          res.body.uploadDir = '';
-          res.body.uploadPath = '';
-        })
+        .expect(resetBodyUploadData)
         .expect(200, {
           name: fileName,
           md5: fileHash,
@@ -178,10 +171,7 @@ describe('Test Single File Upload w/ .mv()', function() {
       request(app)
         .post('/upload/single')
         .attach('testFile', filePath)
-        .expect((res)=>{
-          res.body.uploadDir = '';
-          res.body.uploadPath = '';
-        })
+        .expect(resetBodyUploadData)
         .expect(200, {
           name: fileName,
           md5: fileHash,
@@ -200,7 +190,7 @@ describe('Test Single File Upload w/ .mv()', function() {
   }
 });
 
-describe('Test Single File Upload with useTempFiles option set to true', function() {
+describe('Test Single File Upload with useTempFiles option.', function() {
   const app = server.setup({
     useTempFiles: true,
     tempFileDir: '/tmp/'
@@ -221,10 +211,7 @@ describe('Test Single File Upload with useTempFiles option set to true', functio
       request(app)
         .post('/upload/single')
         .attach('testFile', filePath)
-        .expect((res)=>{
-          res.body.uploadDir = '';
-          res.body.uploadPath = '';
-        })
+        .expect(resetBodyUploadData)
         .expect(200, {
           name: fileName,
           md5: fileHash,
@@ -232,11 +219,8 @@ describe('Test Single File Upload with useTempFiles option set to true', functio
           uploadDir: '',
           uploadPath: ''
         })
-        .end(function(err) {
-          if (err) {
-            return done(err);
-          }
-
+        .end((err) => {
+          if (err) return done(err);
           fs.stat(uploadedFilePath, done);
         });
     });
@@ -253,10 +237,7 @@ describe('Test Single File Upload with useTempFiles option set to true', functio
       request(app)
         .post('/upload/single')
         .attach('testFile', filePath)
-        .expect((res)=>{
-          res.body.uploadDir = '';
-          res.body.uploadPath = '';
-        })
+        .expect(resetBodyUploadData)
         .expect(200, {
           name: fileName,
           md5: fileHash,
@@ -264,11 +245,8 @@ describe('Test Single File Upload with useTempFiles option set to true', functio
           uploadDir: '',
           uploadPath: ''
         })
-        .end(function(err) {
-          if (err) {
-            return done(err);
-          }
-
+        .end((err) => {
+          if (err) return done(err);
           fs.stat(uploadedFilePath, done);
         });
     });
@@ -302,6 +280,43 @@ describe('Test Single File Upload with useTempFiles option set to true', functio
   });
 });
 
+describe('Test Single File Upload with useTempFiles option and empty tempFileDir.', function() {
+  const app = server.setup({
+    useTempFiles: true,
+    tempFileDir: ''
+  });
+
+  for (let i = 0; i < mockFiles.length; i++) {
+    let fileName = mockFiles[i];
+
+    it(`upload ${fileName} with POST`, function(done) {
+      let filePath = path.join(fileDir, fileName);
+      let fileBuffer = fs.readFileSync(filePath);
+      let fileHash = md5(fileBuffer);
+      let fileStat = fs.statSync(filePath);
+      let uploadedFilePath = path.join(uploadDir, fileName);
+
+      clearUploadsDir();
+
+      request(app)
+        .post('/upload/single')
+        .attach('testFile', filePath)
+        .expect(resetBodyUploadData)
+        .expect(200, {
+          name: fileName,
+          md5: fileHash,
+          size: fileStat.size,
+          uploadDir: '',
+          uploadPath: ''
+        })
+        .end((err) => {
+          if (err) return done(err);
+          fs.stat(uploadedFilePath, done);
+        });
+    });
+  }
+});
+
 describe('Test Single File Upload w/ .mv() Promise', function() {
   const app = server.setup();
 
@@ -320,10 +335,7 @@ describe('Test Single File Upload w/ .mv() Promise', function() {
       request(app)
         .post('/upload/single/promise')
         .attach('testFile', filePath)
-        .expect((res)=>{
-          res.body.uploadDir = '';
-          res.body.uploadPath = '';
-        })
+        .expect(resetBodyUploadData)
         .expect(200, {
           name: fileName,
           md5: fileHash,
@@ -331,11 +343,8 @@ describe('Test Single File Upload w/ .mv() Promise', function() {
           uploadDir: '',
           uploadPath: ''
         })
-        .end(function(err) {
-          if (err) {
-            return done(err);
-          }
-
+        .end((err) => {
+          if (err) return done(err);
           fs.stat(uploadedFilePath, done);
         });
     });
@@ -352,10 +361,7 @@ describe('Test Single File Upload w/ .mv() Promise', function() {
       request(app)
         .post('/upload/single/promise')
         .attach('testFile', filePath)
-        .expect((res)=>{
-          res.body.uploadDir = '';
-          res.body.uploadPath = '';
-        })
+        .expect(resetBodyUploadData)
         .expect(200, {
           name: fileName,
           md5: fileHash,
@@ -363,11 +369,8 @@ describe('Test Single File Upload w/ .mv() Promise', function() {
           uploadDir: '',
           uploadPath: ''
         })
-        .end(function(err) {
-          if (err) {
-            return done(err);
-          }
-
+        .end((err) => {
+          if (err) return done(err);
           fs.stat(uploadedFilePath, done);
         });
     });
@@ -422,10 +425,7 @@ describe('Test Single File Upload w/ .mv() Promise and useTempFiles set to true'
       request(app)
         .post('/upload/single/promise')
         .attach('testFile', filePath)
-        .expect((res)=>{
-          res.body.uploadDir = '';
-          res.body.uploadPath = '';
-        })
+        .expect(resetBodyUploadData)
         .expect(200, {
           name: fileName,
           md5: fileHash,
@@ -433,11 +433,8 @@ describe('Test Single File Upload w/ .mv() Promise and useTempFiles set to true'
           uploadDir: '',
           uploadPath: ''
         })
-        .end(function(err) {
-          if (err) {
-            return done(err);
-          }
-
+        .end((err) => {
+          if (err) return done(err);
           fs.stat(uploadedFilePath, done);
         });
     });
@@ -454,10 +451,7 @@ describe('Test Single File Upload w/ .mv() Promise and useTempFiles set to true'
       request(app)
         .post('/upload/single/promise')
         .attach('testFile', filePath)
-        .expect((res)=>{
-          res.body.uploadDir = '';
-          res.body.uploadPath = '';
-        })
+        .expect(resetBodyUploadData)
         .expect(200, {
           name: fileName,
           md5: fileHash,
@@ -465,11 +459,8 @@ describe('Test Single File Upload w/ .mv() Promise and useTempFiles set to true'
           uploadDir: '',
           uploadPath: ''
         })
-        .end(function(err) {
-          if (err) {
-            return done(err);
-          }
-
+        .end((err) => {
+          if (err) return done(err);
           fs.stat(uploadedFilePath, done);
         });
     });
@@ -530,7 +521,7 @@ describe('Test Multi-File Upload', function() {
     });
 
     req
-      .expect((res)=>{
+      .expect((res) => {
         res.body.forEach(fileInfo => {
           fileInfo.uploadDir = '';
           fileInfo.uploadPath = '';
@@ -539,21 +530,12 @@ describe('Test Multi-File Upload', function() {
         });
       })
       .expect(200, expectedResultSorted)
-      .end(function(err) {
-        if (err) {
-          return done(err);
-        }
-
-        fs.stat(uploadedFilesPath[0], function(err) {
-          if (err) {
-            return done(err);
-          }
-
+      .end((err) => {
+        if (err) return done(err);
+        fs.stat(uploadedFilesPath[0], (err) => {
+          if (err) return done(err);
           fs.stat(uploadedFilesPath[1], function(err) {
-            if (err) {
-              return done(err);
-            }
-
+            if (err) return done(err);
             fs.stat(uploadedFilesPath[2], done);
           });
         });
@@ -596,15 +578,11 @@ describe('Test File Array Upload', function() {
         });
       })
       .expect(200, expectedResultSorted)
-      .end(function(err) {
-        if (err) {
-          return done(err);
-        }
-
-        uploadedFilesPath.forEach(function(uploadedFilePath){
+      .end((err) => {
+        if (err) return done(err);
+        uploadedFilesPath.forEach((uploadedFilePath) => {
           fs.statSync(uploadedFilePath);
         });
-
         done();
       });
   });
@@ -631,10 +609,7 @@ describe('Test Upload With Fields', function() {
         .field('firstName', mockUser.firstName)
         .field('lastName', mockUser.lastName)
         .field('email', mockUser.email)
-        .expect((res)=>{
-          res.body.uploadDir = '';
-          res.body.uploadPath = '';
-        })
+        .expect(resetBodyUploadData)
         .expect(200, {
           firstName: mockUser.firstName,
           lastName: mockUser.lastName,
@@ -646,10 +621,7 @@ describe('Test Upload With Fields', function() {
           uploadPath: ''
         },
         function(err) {
-          if (err) {
-            return done(err);
-          }
-
+          if (err) return done(err);
           fs.stat(uploadedFilePath, done);
         });
     });
@@ -670,10 +642,7 @@ describe('Test Upload With Fields', function() {
         .field('firstName', mockUser.firstName)
         .field('lastName', mockUser.lastName)
         .field('email', mockUser.email)
-        .expect((res)=>{
-          res.body.uploadDir = '';
-          res.body.uploadPath = '';
-        })
+        .expect(resetBodyUploadData)
         .expect(200, {
           firstName: mockUser.firstName,
           lastName: mockUser.lastName,
@@ -685,10 +654,7 @@ describe('Test Upload With Fields', function() {
           uploadPath: ''
         },
         function(err) {
-          if (err) {
-            return done(err);
-          }
-
+          if (err) return done(err);
           fs.stat(uploadedFilePath, done);
         });
     });

--- a/test/utilities.spec.js
+++ b/test/utilities.spec.js
@@ -13,6 +13,7 @@ const {
   errorFunc,
   getTempFilename,
   buildOptions,
+  buildFields,
   checkAndMakeDir,
   deleteFile,
   copyFile,

--- a/test/utilities.spec.js
+++ b/test/utilities.spec.js
@@ -191,6 +191,16 @@ describe('Test of the utilities functions', function() {
     });    
 
   });
+  //buildFields tests
+  describe('Test buildOptions function', () => {
+  
+    it('buildFields does nothing if null value has been passed', () => {
+      let fields = null;
+      fields = buildFields(fields, 'test', null);
+      assert.equal(fields, null);
+    });
+
+  });
   //checkAndMakeDir tests
   describe('Test checkAndMakeDir function', () => {
     //


### PR DESCRIPTION
Make it lighter
Change multipart regexp to /^(multipart\/.+);(.*)$/i
Move empty files check to the fileFactory and add tests for it