### PR TITLE
if possible, use fs.rename for moveFile instead of copyFile

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -154,8 +154,14 @@ const copyFile = (src, dst, callback) => {
  * @param {Function} callback - A callback function.
  */
 const moveFile = (src, dst, callback) => {
-  // Copy file to dst and delete src whether success.
-  copyFile(src, dst, err => err ? callback(err) : deleteFile(src, callback));
+  fs.rename(src, dst, err => {
+    if (err) {
+      // Copy file to dst and delete src whether success.
+      copyFile(src, dst, err => err ? callback(err) : deleteFile(src, callback));      
+      return;
+    }
+    callback();
+  });
 };
 
 /**


### PR DESCRIPTION
try to rename a (temporary) file before resorting to copyFile. fs.rename is much faster for large files and requires less empty disk space.