### PR TITLE
fix: upload timer starts even no data has come.

### DIFF
--- a/lib/processMultipart.js
+++ b/lib/processMultipart.js
@@ -40,20 +40,28 @@ module.exports = (options, req, res, next) => {
 
   // Build req.files fields
   busboy.on('file', (field, file, name, encoding, mime) => {
-    // Define upload timer settings
-    let uploadTimer = null;
-    const timeout = options.uploadTimeout;
     // Parse file name(cutting huge names, decoding, etc..).
     const filename = parseFileName(options, name);
     // Define methods and handlers for upload process.
     const {dataHandler, getFilePath, getFileSize, getHash, complete, cleanup} = options.useTempFiles
       ? tempFileHandler(options, field, filename) // Upload into temporary file.
       : memHandler(options, field, filename);     // Upload into RAM.
+    // Define upload timer settings and clear/set functions.
+    let uploadTimer = null;
+    const timeout = options.uploadTimeout;
+    const clearUploadTimer = () => clearTimeout(uploadTimer);
+    const setUploadTimer = () => {
+      clearUploadTimer();
+      uploadTimer = setTimeout(() => {
+        debugLog(options, `Upload timeout ${field}->${filename}, bytes:${getFileSize()}`);
+        cleanup();
+      }, timeout);
+    };
 
     file.on('limit', () => {
       debugLog(options, `Size limit reached for ${field}->${filename}, bytes:${getFileSize()}`);
       // Reset upload timer in case of file limit reached.
-      clearTimeout(uploadTimer);
+      clearUploadTimer();
       // Run a user defined limit handler if it has been set.
       if (isFunc(options.limitHandler)) return options.limitHandler(req, res, next);
       // Close connection with 413 code and do cleanup if abortOnLimit set(default: false).
@@ -65,21 +73,15 @@ module.exports = (options, req, res, next) => {
     });
 
     file.on('data', (data) => {
-      // Reset and set new upload timer each time when new data came.
-      clearTimeout(uploadTimer);
-      uploadTimer = setTimeout(() => {
-        debugLog(options, `Upload timeout ${field}->${filename}, bytes:${getFileSize()}`);
-        cleanup();
-      }, timeout);
-      // Handle new piece of data.
-      dataHandler(data);
+      setUploadTimer(); // Set upload timer each time new data chunk came.
+      dataHandler(data); // Handle new piece of data.
     });
 
     file.on('end', () => {
       // Debug logging for a new file upload.
       debugLog(options, `Upload finished ${field}->${filename}, bytes:${getFileSize()}`);
       // Reset upload timer in case of end event.
-      clearTimeout(uploadTimer);
+      clearUploadTimer();
       // Add file instance to the req.files
       req.files = buildFields(req.files, field, fileFactory({
         buffer: complete(),
@@ -95,7 +97,7 @@ module.exports = (options, req, res, next) => {
 
     file.on('error', (err) => {
       // Reset upload timer in case of errors.
-      clearTimeout(uploadTimer);
+      clearUploadTimer();
       debugLog(options, `Error ${field}->${filename}, bytes:${getFileSize()}, error:${err}`);
       cleanup();
       next();
@@ -103,6 +105,8 @@ module.exports = (options, req, res, next) => {
 
     // Debug logging for a new file upload.
     debugLog(options, `New upload started ${field}->${filename}, bytes:${getFileSize()}`);
+    // Set new upload timeout for a new file.
+    setUploadTimer();
   });
 
   busboy.on('finish', () => {


### PR DESCRIPTION
Previously upload timeout timer started only after first data chunk came.
If no data came at all timeout doesn't start so no cleanup will be performed in this case.