### PR TITLE
Get original file extension of the uploaded file

### DIFF
--- a/lib/fileFactory.js
+++ b/lib/fileFactory.js
@@ -44,6 +44,7 @@ module.exports = (options, fileUploadOptions = {}) => {
   // Create and return file object.
   return {
     name: options.name,
+    extension : options.extension,
     data: options.buffer,
     size: options.size,
     encoding: options.encoding,

--- a/lib/processMultipart.js
+++ b/lib/processMultipart.js
@@ -8,7 +8,8 @@ const {
   debugLog,
   buildFields,
   buildOptions,
-  parseFileName
+  parseFileName,
+  getFileExtension
 } = require('./utilities');
 
 /**
@@ -42,6 +43,11 @@ module.exports = (options, req, res, next) => {
   busboy.on('file', (field, file, name, encoding, mime) => {
     // Parse file name(cutting huge names, decoding, etc..).
     const filename = parseFileName(options, name);
+    
+    ////added by haxpak@gmail.com
+    const extension = getFileExtension(options, name);
+    /////
+
     // Define methods and handlers for upload process.
     const {dataHandler, getFilePath, getFileSize, getHash, complete, cleanup} = options.useTempFiles
       ? tempFileHandler(options, field, filename) // Upload into temporary file.
@@ -86,6 +92,7 @@ module.exports = (options, req, res, next) => {
       req.files = buildFields(req.files, field, fileFactory({
         buffer: complete(),
         name: filename,
+        extension : extension,
         tempFilePath: getFilePath(),
         size: getFileSize(),
         hash: getHash(),

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -250,6 +250,25 @@ const parseFileName = (opts, fileName) => {
   return name.replace(nameRegex, '').concat(extension);
 };
 
+
+/**
+ * Parse file original extension.
+ * @param opts {Object}     - middleware options.
+ * @param fileName {String} - Uploaded file name.
+ * @returns {String}
+ * 
+ * added by haxpak@gmail.com
+ */
+
+const getFileExtension = (opts, fileName) => {
+  const extension = '';
+  const nameParts = fileName.split('.');
+  if (nameParts.length < 2) return extension;
+
+  return nameParts.pop();
+};
+
+
 module.exports = {
   debugLog,
   isFunc,
@@ -264,5 +283,6 @@ module.exports = {
   saveBufferToFile,
   parseFileName,
   getTempFilename,
-  uriDecodeFileName
+  uriDecodeFileName,
+  getFileExtension // added by haxpak@gmail.com
 };


### PR DESCRIPTION
I had a need to get the original file extension from the uploaded file.

I was initially using the split pop method in my code to get the extension, however though that it might be useful as a feature.
so forked and added the same to the main code.

the object req.files.<name>

now has a property extension

extension:"docx"