### PR TITLE
fix: add error handler to tempFileHandler

### DIFF
--- a/lib/memHandler.js
+++ b/lib/memHandler.js
@@ -29,6 +29,6 @@ module.exports = (options, fieldname, filename) => {
     getHash: () => hash.digest('hex'),
     complete: getBuffer,
     cleanup: emptyFunc,
-    finish: () => Promise.resolve()
+    getWritePromise: () => Promise.resolve()
   };
 };

--- a/lib/processMultipart.js
+++ b/lib/processMultipart.js
@@ -11,6 +11,8 @@ const {
   parseFileName
 } = require('./utilities');
 
+const waitFlushProperty = Symbol('wait flush property symbol')
+
 /**
  * Processes multipart request
  * Builds a req.body object for fields
@@ -43,7 +45,7 @@ module.exports = (options, req, res, next) => {
     // Parse file name(cutting huge names, decoding, etc..).
     const filename = parseFileName(options, name);
     // Define methods and handlers for upload process.
-    const {dataHandler, getFilePath, getFileSize, getHash, complete, cleanup, finish} = options.useTempFiles
+    const {dataHandler, getFilePath, getFileSize, getHash, complete, cleanup, getWritePromise} = options.useTempFiles
       ? tempFileHandler(options, field, filename) // Upload into temporary file.
       : memHandler(options, field, filename);     // Upload into RAM.
     // Define upload timer settings and clear/set functions.
@@ -94,10 +96,10 @@ module.exports = (options, req, res, next) => {
         mimetype: mime
       }, options));
 
-      if (!req.waits) {
-        req.waits = [];
+      if (!req[waitFlushProperty]) {
+        req[waitFlushProperty] = [];
       }
-      req.waits.push(finish());
+      req[waitFlushProperty].push(getWritePromise());
     });
 
     file.on('error', (err) => {
@@ -115,19 +117,25 @@ module.exports = (options, req, res, next) => {
   });
 
   busboy.on('finish', () => {
-    const handler = () => {
+    const handler = (err) => {
       if (options.parseNested) {
         req.body = processNested(req.body);
         req.files = processNested(req.files);
       }
-      next();
+      next(err);
     };
 
-    if (req.waits) {
-      Promise.all(req.waits).then(() => {
-        delete req.waits;
-        handler();
-      });
+    if (req[waitFlushProperty]) {
+      Promise.all(req[waitFlushProperty])
+        .then(() => {
+          delete req[waitFlushProperty];
+          handler();
+        })
+        .catch(err => {
+          delete req[waitFlushProperty];
+          debugLog(options, `Error wait flush error:${err}`);
+          handler(err)
+        });
     } else {
       handler();
     }

--- a/lib/processMultipart.js
+++ b/lib/processMultipart.js
@@ -11,7 +11,7 @@ const {
   parseFileName
 } = require('./utilities');
 
-const waitFlushProperty = Symbol('wait flush property symbol')
+const waitFlushProperty = Symbol('wait flush property symbol');
 
 /**
  * Processes multipart request
@@ -45,7 +45,15 @@ module.exports = (options, req, res, next) => {
     // Parse file name(cutting huge names, decoding, etc..).
     const filename = parseFileName(options, name);
     // Define methods and handlers for upload process.
-    const {dataHandler, getFilePath, getFileSize, getHash, complete, cleanup, getWritePromise} = options.useTempFiles
+    const {
+      dataHandler,
+      getFilePath,
+      getFileSize,
+      getHash,
+      complete,
+      cleanup,
+      getWritePromise
+    } = options.useTempFiles
       ? tempFileHandler(options, field, filename) // Upload into temporary file.
       : memHandler(options, field, filename);     // Upload into RAM.
     // Define upload timer settings and clear/set functions.
@@ -134,7 +142,7 @@ module.exports = (options, req, res, next) => {
         .catch(err => {
           delete req[waitFlushProperty];
           debugLog(options, `Error wait flush error:${err}`);
-          handler(err)
+          handler(err);
         });
     } else {
       handler();

--- a/lib/tempFileHandler.js
+++ b/lib/tempFileHandler.js
@@ -18,10 +18,14 @@ module.exports = (options, fieldname, filename) => {
   const hash = crypto.createHash('md5');
   const writeStream = fs.createWriteStream(tempFilePath);
   let fileSize = 0; // eslint-disable-line
-  const promise = new Promise((resolve) => {
+  const promise = new Promise((resolve, reject) => {
     writeStream.on('finish', () => {
       resolve();
     });
+    writeStream.on('error', (err) => {
+      debugLog(options, `Error write temp file error:${err}`);
+      reject(err)
+    })
   });
 
   return {
@@ -44,7 +48,7 @@ module.exports = (options, fieldname, filename) => {
       writeStream.end();
       deleteFile(tempFilePath, (err) => { if (err) throw err; });
     },
-    finish: () => {
+    getWritePromise: () => {
       return promise;
     }
   };

--- a/lib/tempFileHandler.js
+++ b/lib/tempFileHandler.js
@@ -24,8 +24,8 @@ module.exports = (options, fieldname, filename) => {
     });
     writeStream.on('error', (err) => {
       debugLog(options, `Error write temp file error:${err}`);
-      reject(err)
-    })
+      reject(err);
+    });
   });
 
   return {


### PR DESCRIPTION
I did some optimization for PR #189 

- Add error handler to tempFileHandler writeStream
- Use 'Symbol' to prevent external access promises