### PR TITLE
fix: Add empty file name check for parseFileName.

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -228,11 +228,13 @@ const parseFileNameExtension = (preserveExtension, fileName) => {
 
 /**
  * Parse file name and extension.
- * @param opts {Object}     - middleware options.
- * @param fileName {String} - Uploaded file name.
- * @returns {String}
+ * @param {Object} opts - middleware options.
+ * @param {string} fileName - Uploaded file name.
+ * @returns {string}
  */
 const parseFileName = (opts, fileName) => {
+  // Check fileName argument
+  if (!fileName || typeof fileName !== 'string') return getTempFilename();
   // Cut off file name if it's lenght more then 255.
   let parsedName = fileName.length <= 255 ? fileName : fileName.substr(0, 255);
   // Decode file name if uriDecodeFileNames option set true.

--- a/test/utilities.spec.js
+++ b/test/utilities.spec.js
@@ -174,6 +174,12 @@ describe('Test of the utilities functions', function() {
         assert.equal(result, expected);
       });
 
+    it('Returns a temporary file name if name argument is empty.', () => {
+      const opts = {safeFileNames: false};
+      const result = parseFileName(opts);
+      assert.equal(typeof result, 'string');
+    });
+
   });
   //buildOptions tests
   describe('Test buildOptions function', () => {


### PR DESCRIPTION
fix: Add empty file name check for parseFileName.
That fixes issue #187 