### PR TITLE
Fix #239

### DIFF
--- a/lib/processNested.js
+++ b/lib/processNested.js
@@ -1,4 +1,6 @@
-const INVALID_KEYS = ['__proto__', 'constructor'];
+const OBJECT_PROTOTYPE_KEYS = Object.getOwnPropertyNames(Object.prototype);
+const ARRAY_PROTOTYPE_KEYS = Object.getOwnPropertyNames(Array.prototype);
+
 
 module.exports = function(data){
   if (!data || data.length < 1) return {};
@@ -19,7 +21,7 @@ module.exports = function(data){
       let k = keyParts[index];
 
       // Ensure we don't allow prototype pollution
-      if (INVALID_KEYS.includes(k)) {
+      if (OBJECT_PROTOTYPE_KEYS.includes(k) || (ARRAY_PROTOTYPE_KEYS.includes(k) && Array.isArray(current)) {
         continue;
       }
 

--- a/lib/processNested.js
+++ b/lib/processNested.js
@@ -21,7 +21,7 @@ module.exports = function(data){
       let k = keyParts[index];
 
       // Ensure we don't allow prototype pollution
-      if (OBJECT_PROTOTYPE_KEYS.includes(k) || (ARRAY_PROTOTYPE_KEYS.includes(k) && Array.isArray(current)) {
+      if (OBJECT_PROTOTYPE_KEYS.includes(k) || (ARRAY_PROTOTYPE_KEYS.includes(k) && Array.isArray(current))) {
         continue;
       }
 
@@ -33,6 +33,8 @@ module.exports = function(data){
       }
     }
   }
+  
+  
   
   return d;
 };

--- a/lib/processNested.js
+++ b/lib/processNested.js
@@ -21,7 +21,8 @@ module.exports = function(data){
       let k = keyParts[index];
 
       // Ensure we don't allow prototype pollution
-      if (OBJECT_PROTOTYPE_KEYS.includes(k) || (ARRAY_PROTOTYPE_KEYS.includes(k) && Array.isArray(current))) {
+      const IN_ARRAY_PROTOTYPE = ARRAY_PROTOTYPE_KEYS.includes(k) && Array.isArray(current);
+      if (OBJECT_PROTOTYPE_KEYS.includes(k) || IN_ARRAY_PROTOTYPE) {
         continue;
       }
 


### PR DESCRIPTION
Fixes #239 

This simply replaces a single array of invalid keys that is manually set with two separate ones for the `Object` and `Array` prototypes in order to block all potentially harmful keys from being set.  Since all objects inherit from the `Object` prototype, the array for the `Object` prototype is not conditional based on the type of the current object with the property being set.