### PR TITLE
Remove empty files

### DIFF
--- a/lib/processMultipart.js
+++ b/lib/processMultipart.js
@@ -94,7 +94,7 @@ module.exports = (options, req, res, next) => {
       // Do not add file instance to the req.files if original name and size are empty.
       // Empty name and zero size indicates empty file field in the posted form.
       if (!name && size === 0) {
-        if(options.useTempFiles) {
+        if (options.useTempFiles) {
           cleanup();
         }
         return debugLog(options, `Don't add file instance if original name and size are empty`);

--- a/lib/processMultipart.js
+++ b/lib/processMultipart.js
@@ -96,6 +96,7 @@ module.exports = (options, req, res, next) => {
       if (!name && size === 0) {
         if (options.useTempFiles) {
           cleanup();
+          debugLog(options, `Removing the empty file ${field}->${filename}`);
         }
         return debugLog(options, `Don't add file instance if original name and size are empty`);
       }

--- a/lib/processMultipart.js
+++ b/lib/processMultipart.js
@@ -11,6 +11,7 @@ const {
   buildOptions,
   parseFileName
 } = require('./utilities');
+const { raw } = require('body-parser');
 
 const waitFlushProperty = Symbol('wait flush property symbol');
 
@@ -94,6 +95,9 @@ module.exports = (options, req, res, next) => {
       // Do not add file instance to the req.files if original name and size are empty.
       // Empty name and zero size indicates empty file field in the posted form.
       if (!name && size === 0) {
+        if(options.useTempFiles){
+          cleanup();
+        }
         return debugLog(options, `Don't add file instance if original name and size are empty`);
       }
       req.files = buildFields(req.files, field, fileFactory({

--- a/lib/processMultipart.js
+++ b/lib/processMultipart.js
@@ -11,7 +11,6 @@ const {
   buildOptions,
   parseFileName
 } = require('./utilities');
-const { raw } = require('body-parser');
 
 const waitFlushProperty = Symbol('wait flush property symbol');
 

--- a/lib/processMultipart.js
+++ b/lib/processMultipart.js
@@ -94,7 +94,7 @@ module.exports = (options, req, res, next) => {
       // Do not add file instance to the req.files if original name and size are empty.
       // Empty name and zero size indicates empty file field in the posted form.
       if (!name && size === 0) {
-        if(options.useTempFiles){
+        if(options.useTempFiles) {
           cleanup();
         }
         return debugLog(options, `Don't add file instance if original name and size are empty`);


### PR DESCRIPTION
Follow up PR for #233

#233 seemed to exclude empty files from req.files but for temporary files, it still creates a writestream right after busboy triggers the `.on("file")` method, I did some research in hopes to find a flag for `fs.createWriteStream` to actually check and remove if the file is empty on the end but there's no such a thing.

And we are not able to **not** create a stream while we can't get the size info until the end, so the best thing we can do is follow the condition we have on `file.on('end')` and cleanup if `temporaryFiles` is enabled.