### PR TITLE
Added 'hashAlgorithm' options to use another algorithm for hashing file content other than md5

### DIFF
--- a/lib/fileFactory.js
+++ b/lib/fileFactory.js
@@ -40,7 +40,7 @@ module.exports = (options, fileUploadOptions = {}) => {
   // firefox uploads empty file in case of cache miss when f5ing page.
   // resulting in unexpected behavior. if there is no file data, the file is invalid.
   // if (!fileUploadOptions.useTempFiles && !options.buffer.length) return;
-  
+
   // Create and return file object.
   return {
     name: options.name,
@@ -50,7 +50,7 @@ module.exports = (options, fileUploadOptions = {}) => {
     tempFilePath: options.tempFilePath,
     truncated: options.truncated,
     mimetype: options.mimetype,
-    md5: options.hash,
+    [fileUploadOptions.hashAlgorithm]: options.hash,
     mv: (filePath, callback) => {
       // Define a propper move function.
       const moveFunc = fileUploadOptions.useTempFiles

--- a/lib/fileFactory.js
+++ b/lib/fileFactory.js
@@ -50,7 +50,7 @@ module.exports = (options, fileUploadOptions = {}) => {
     tempFilePath: options.tempFilePath,
     truncated: options.truncated,
     mimetype: options.mimetype,
-    [fileUploadOptions.hashAlgorithm]: options.hash,
+    [fileUploadOptions.hashAlgorithm || 'md5']: options.hash,
     mv: (filePath, callback) => {
       // Define a propper move function.
       const moveFunc = fileUploadOptions.useTempFiles

--- a/lib/index.js
+++ b/lib/index.js
@@ -18,6 +18,7 @@ const DEFAULT_OPTIONS = {
   createParentPath: false,
   parseNested: false,
   useTempFiles: false,
+  hashAlgorithm: 'md5',
   tempFileDir: path.join(process.cwd(), 'tmp')
 };
 

--- a/lib/memHandler.js
+++ b/lib/memHandler.js
@@ -10,7 +10,7 @@ const { debugLog } = require('./utilities');
  */
 module.exports = (options, fieldname, filename) => {
   const buffers = [];
-  const hash = crypto.createHash('md5');
+  const hash = crypto.createHash(options.hashAlgorithm);
   let fileSize = 0;
   let completed = false;
 

--- a/lib/tempFileHandler.js
+++ b/lib/tempFileHandler.js
@@ -14,8 +14,8 @@ module.exports = (options, fieldname, filename) => {
   checkAndMakeDir({ createParentPath: true }, tempFilePath);
 
   debugLog(options, `Temporary file path is ${tempFilePath}`);
- 
-  const hash = crypto.createHash('md5');
+
+  const hash = crypto.createHash(options.hashAlgorithm);
   let fileSize = 0;
   let completed = false;
 
@@ -54,7 +54,7 @@ module.exports = (options, fieldname, filename) => {
       completed = true;
       debugLog(options, `Cleaning up temporary file ${tempFilePath}...`);
       writeStream.end();
-      deleteFile(tempFilePath, err => (err 
+      deleteFile(tempFilePath, err => (err
         ? debugLog(options, `Cleaning up temporary file ${tempFilePath} failed: ${err}`)
         : debugLog(options, `Cleaning up temporary file ${tempFilePath} done.`)
       ));


### PR DESCRIPTION
Like the title said, this PR added 'hashAlgorithm' options to specify other hash algorithm than md5.

In my use case, i need sha1 content hash instead of md5 so i will use its like:
```js
const fileUpload = require('express-fileupload');

// omited

app.use(fileUpload({ 
    useTempFiles: true,
    hashAlgorithm: 'sha1',
});

app.post('/upload', (req, res) => {
    console.log('File content sha1 hash: ' + req.files.file.sha1);
    res.send('Ok');
});
```