### PR TITLE
Removed finish event if file-size limit reached

### DIFF
--- a/lib/processMultipart.js
+++ b/lib/processMultipart.js
@@ -33,9 +33,11 @@ module.exports = (options, req, res, next) => {
 
   // Close connection with specified reason and http code, default: 400 Bad Request.
   const closeConnection = (code, reason) => {
-    req.unpipe(busboy);
-    res.writeHead(code || 400, { Connection: 'close' });
-    res.end(reason || 'Bad Request');
+    if(!res.headersSent) {
+      req.unpipe(busboy);
+      res.writeHead(code || 400, { Connection: 'close' });
+      res.end(reason || 'Bad Request');
+    }
   };
 
   // Build multipart req.body fields
@@ -70,9 +72,11 @@ module.exports = (options, req, res, next) => {
       // Reset upload timer in case of file limit reached.
       uploadTimer.clear();
       // Run a user defined limit handler if it has been set.
-      if (isFunc(options.limitHandler)) return options.limitHandler(req, res, next);
+      if (isFunc(options.limitHandler)) options.limitHandler(req, res, next);
+      
       // Close connection with 413 code and do cleanup if abortOnLimit set(default: false).
       if (options.abortOnLimit) {
+        busboy.removeListener('finish', finishListener)
         debugLog(options, `Aborting upload because of size limit ${field}->${filename}.`);
         closeConnection(413, options.responseOnLimit);
         cleanup();
@@ -130,7 +134,7 @@ module.exports = (options, req, res, next) => {
     uploadTimer.set();
   });
 
-  busboy.on('finish', () => {
+  function finishListener() {
     debugLog(options, `Busboy finished parsing request.`);
     if (options.parseNested) {
       req.body = processNested(req.body);
@@ -147,7 +151,8 @@ module.exports = (options, req, res, next) => {
         debugLog(options, `Error while waiting files flush: ${err}`);
         next(err);
       });
-  });
+  }
+  busboy.on('finish', finishListener);
 
   busboy.on('error', (err) => {
     debugLog(options, `Busboy error`);


### PR DESCRIPTION
Also allowed limitHandler and abortOnLimit to exist simultaneously without headers already sent error.
Solves #238.