### PR TITLE
Unhandled promise rejection warning

### DIFF
--- a/lib/processMultipart.js
+++ b/lib/processMultipart.js
@@ -57,6 +57,16 @@ module.exports = (options, req, res, next) => {
     } = options.useTempFiles
       ? tempFileHandler(options, field, filename) // Upload into temporary file.
       : memHandler(options, field, filename);     // Upload into RAM.
+
+    const writePromise = getWritePromise();
+    if (options.useTempFiles) {
+      writePromise.catch(err => {
+        uploadTimer.clear();
+        cleanup();
+        next(err);
+      });
+    }
+
     // Define upload timer.
     const uploadTimer = new UploadTimer(options.uploadTimeout, () => {
       file.removeAllListeners('data');
@@ -114,7 +124,7 @@ module.exports = (options, req, res, next) => {
       if (!req[waitFlushProperty]) {
         req[waitFlushProperty] = [];
       }
-      req[waitFlushProperty].push(getWritePromise());
+      req[waitFlushProperty].push(writePromise);
     });
 
     file.on('error', (err) => {

--- a/lib/processMultipart.js
+++ b/lib/processMultipart.js
@@ -58,14 +58,12 @@ module.exports = (options, req, res, next) => {
       ? tempFileHandler(options, field, filename) // Upload into temporary file.
       : memHandler(options, field, filename);     // Upload into RAM.
 
-    const writePromise = getWritePromise();
-    if (options.useTempFiles) {
-      writePromise.catch(err => {
+    const writePromise = options.useTempFiles
+      ? getWritePromise().catch(err => {
         uploadTimer.clear();
         cleanup();
         next(err);
-      });
-    }
+      }) : getWritePromise();
 
     // Define upload timer.
     const uploadTimer = new UploadTimer(options.uploadTimeout, () => {
@@ -152,10 +150,6 @@ module.exports = (options, req, res, next) => {
       .then(() => {
         delete req[waitFlushProperty];
         next();
-      }).catch(err => {
-        delete req[waitFlushProperty];
-        debugLog(options, `Error while waiting files flush: ${err}`);
-        next(err);
       });
   });
 

--- a/lib/processMultipart.js
+++ b/lib/processMultipart.js
@@ -60,7 +60,8 @@ module.exports = (options, req, res, next) => {
 
     const writePromise = options.useTempFiles
       ? getWritePromise().catch(err => {
-        uploadTimer.clear();
+        req.unpipe(busboy);
+        req.resume();
         cleanup();
         next(err);
       }) : getWritePromise();


### PR DESCRIPTION
Hi, I think that catching writePromise rejection on busboy _finish_ event seems too late, because it happens at  `dataHandler(data)` on busboy _data_ event and already in this point promise should have its reject callback in case of stream write errors. 
 
The best solution on writePromise rejection would be stop fetching rest of the request to not waste the bandwidth, similar like it is done in `closeConnection()` and then call `next(err)` error handler (not `next()` middleware`, but for now I don't get a well-functioning solution for that just this one.  