### PR TITLE
(Fix) Stopped additional responses from being sent if a limit handler exists

### DIFF
--- a/lib/processMultipart.js
+++ b/lib/processMultipart.js
@@ -74,7 +74,7 @@ module.exports = (options, req, res, next) => {
       // Close connection with 413 code and do cleanup if abortOnLimit set(default: false).
       if (options.abortOnLimit) {
         debugLog(options, `Aborting upload because of size limit ${field}->${filename}.`);
-        closeConnection(413, options.responseOnLimit);
+        !isFunc(options.limitHandler) ? closeConnection(413, options.responseOnLimit) : '';
         cleanup();
       }
     });


### PR DESCRIPTION
- The method "closeConnection" attempts to send a second response despite the parsed "limitHandler" function initially executing and sending its own custom response.
- This leads to the error - "Error [ERR_HTTP_HEADERS_SENT]: Cannot set headers after they are sent to the client".
- I have placed a condition for the "closeConnection" method to only be executed if a valid "limitHandler" function is NOT parsed into the options argument.