### PR TITLE
Have promiseCallback make callbacks and promises behave the same

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -50,10 +50,19 @@ const errorFunc = (resolve, reject) => isFunc(reject) ? reject : resolve;
 
 /**
  * Return a callback function for promise resole/reject args.
+ * Ensures that callback is called only once.
  * @returns {Function}
  */
 const promiseCallback = (resolve, reject) => {
-  return err => err ? errorFunc(resolve, reject)(err) : resolve();
+  let hasFired = false;
+  return (err) => {
+    if (hasFired) {
+      return;
+    }
+
+    hasFired = true;
+    return err ? errorFunc(resolve, reject)(err) : resolve();
+  };
 };
 
 /**
@@ -177,8 +186,9 @@ const saveBufferToFile = (buffer, filePath, callback) => {
   };
   // Setup file system writable stream.
   let fstream = fs.createWriteStream(filePath);
-  fstream.on('error', err => callback(err));
-  fstream.on('close', () => callback());
+  console.log("Calling saveBuffer");
+  fstream.on('error', err => (console.log("err cb"), callback(err)));
+  fstream.on('close', () => (console.log("close cb"), callback()));
   // Copy file via piping streams.
   readStream.pipe(fstream);
 };


### PR DESCRIPTION
This PR addresses failing tests in `test/fileFactory.spec.js`. These tests were failing because an `fsWriteStream` was emitting both an `error` event and a `close` event that caused the callback to fire twice.

However, this only happened when using a the callback interface to `file.mv`, as the promise interface would naturally "eat" the second event. In order to both fix the tests, and ensure that both promises and callbacks behave the same way to the user, this PR adjusts the behavior of the `promiseCallback` wrapper function to prevent duplicate callbacks. 