### PR TITLE
Fix UTF-8 encoded error

### DIFF
--- a/lib/processMultipart.js
+++ b/lib/processMultipart.js
@@ -49,7 +49,8 @@ module.exports = (options, req, res, next) => {
   busboy.on('file', (field, file, info) => {
     // Parse file name(cutting huge names, decoding, etc..).
     const {filename:name, encoding, mimeType: mime} = info;
-    const filename = parseFileName(options, name);
+    const utf8Name = Buffer.from(name, 'latin1').toString('utf-8');
+    const filename = parseFileName(options, utf8Name);
     // Define methods and handlers for upload process.
     const {
       dataHandler,


### PR DESCRIPTION
I found that in the 1.4.0 update, the Busboy version was updated from 0.3.1 to version 1.6.0.

But the version after Busboy 1.0.0 has removed the encoding, which means that the encoding will be handled by the user.

So in the current express-fileupload 1.4.0 version, the filename will get the wrong encoding:

Correct: 許功蓋.jpg
Wrong: è¨±å\u008a\u009fè\u0093\u008b.jpg

First I tried changing uriDecodeFileNames to true , but it didn't work.

Then I found the Busboy Issue where someone solved this problem:
https://github.com/mscdex/busboy/issues/274#issuecomment-1015483307

After I modified it with reference to this method, the current encoding is correct, I hope it will help you, thank you.