### PR TITLE
Fix richardgirges/express-fileupload#342 URI malformed error

### DIFF
--- a/README.md
+++ b/README.md
@@ -124,7 +124,17 @@ debug | <ul><li><code>false</code>&nbsp;**(default)**</li><li><code>true</code><
 uploadTimeout | <ul><li><code>60000</code>&nbsp;**(default)**</li><li><code>Integer</code></ul> | This defines how long to wait for data before aborting. Set to 0 if you want to turn off timeout checks.
 
 # Help Wanted
-Looking for additional maintainers. Please contact `richardgirges [ at ] gmail.com` if you're interested. Pull Requests are welcome! 
+Looking for additional maintainers. Please contact `richardgirges [ at ] gmail.com` if you're interested. 
+
+Pull Requests are welcome !
+
+Code quality gate (tested via [CircleCI](./.circleci)) :
+- nodeJS version compatibility : 12..17 (cf. circleCi)
+- code lint : `npm run lint` and `npm run lint:fix`
+- green tests : `npm run test`
+- tests coverage : `npm run coverage`
+
+
 
 # Thanks & Credit
 [Brian White](https://github.com/mscdex) for his stellar work on the [Busboy Package](https://github.com/mscdex/busboy) and the [connect-busboy Package](https://github.com/mscdex/connect-busboy)

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -182,7 +182,7 @@ const copyFile = (src, dst, callback) => {
 
 /**
  * moveFile: moves the file from src to dst.
- * Firstly trying to rename the file if no luck copying it to dst and then deleteing src.
+ * First try to rename the file if no luck copy it to dst and then delete src.
  * @param {string} src - Path to the source file
  * @param {string} dst - Path to the destination file.
  * @param {Function} callback - A callback function.
@@ -224,12 +224,26 @@ const saveBufferToFile = (buffer, filePath, callback) => {
 };
 
 /**
- * Decodes uriEncoded file names.
+ * Decodes uriEncoded file names
+ * and remove invalid char range
+ * @param opts {Object} - { uriDecodeFileNames } options
  * @param fileName {String} - file name to decode.
  * @returns {String}
  */
 const uriDecodeFileName = (opts, fileName) => {
-  return opts.uriDecodeFileNames ? decodeURIComponent(fileName) : fileName;
+  if (opts.uriDecodeFileNames && fileName) {
+    try {
+      var decodedFileName = fileName;
+      decodedFileName = decodedFileName.replace(/%91/g, '');// remove %91
+      decodedFileName = decodedFileName.replace(/%92/g, '');// remove %92
+      decodedFileName = decodedFileName.replace(/\uFFFD/g, '');// remove �
+      decodedFileName = decodeURIComponent(decodedFileName);
+    } catch (error) {
+      // ignore decode error // console.error({fileName,error})
+    }
+    return decodedFileName;
+  }
+  return fileName;
 };
 
 /**
@@ -275,7 +289,7 @@ const parseFileNameExtension = (preserveExtension, fileName) => {
 const parseFileName = (opts, fileName) => {
   // Check fileName argument
   if (!fileName || typeof fileName !== 'string') return getTempFilename();
-  // Cut off file name if it's lenght more then 255.
+  // Cut off file name if it's length more then 255.
   let parsedName = fileName.length <= 255 ? fileName : fileName.substr(0, 255);
   // Decode file name if uriDecodeFileNames option set true.
   parsedName = uriDecodeFileName(opts, parsedName);

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
     "test": "nyc  --reporter=html --reporter=text mocha -- -R spec",
     "lint": "eslint ./",
     "lint:fix": "eslint --fix ./",
+    "coverage": "nyc report",
     "coveralls": "nyc report --reporter=text-lcov | coveralls"
   },
   "dependencies": {

--- a/test/utilities.spec.js
+++ b/test/utilities.spec.js
@@ -382,7 +382,10 @@ describe('Test of the utilities functions', function() {
     const testData = [
       { enc: 'test%22filename', dec: 'test"filename' },
       { enc: 'test%60filename', dec: 'test`filename' },
-      { enc: '%3Fx%3Dtest%22filename', dec: '?x=test"filename'}
+      { enc: '%3Fx%3Dtest%22filename', dec: '?x=test"filename'},
+      { enc: '�filename�', dec: 'filename'},
+      { enc: 'bug_bounty_upload_%91and%92.txt', dec: 'bug_bounty_upload_and.txt'},
+      { enc: 'bug_bounty_upload_‘and’.txt', dec: 'bug_bounty_upload_‘and’.txt'}
     ];
 
     // Test decoding if uriDecodeFileNames: true.


### PR DESCRIPTION
Fix #342 URI malformed error

HowTo reproduce source: https://stackoverflow.com/questions/28063750/decodeuricomponent-throwing-an-error-uri-malformed HowTo prevent invalid character credit: https://stackoverflow.com/questions/2670037/how-to-remove-invalid-utf-8-characters-from-a-javascript-string

Thanks: T.J. Crowder
Thanks: Phylogenesis
Thanks: loretoparisi

---

To reviewer remark
- I'm not fan of catching error without feedback. : ` // ignore decode error`
- If you would like introduce an option (`infoOnInvalidFilename`) to log semthing that could be great too.. I dont know...
anyway dont hesitate to amend or append to this fix directly.