### PR TITLE
Fix issue #342:URI malformed error.

### DIFF
--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -229,7 +229,26 @@ const saveBufferToFile = (buffer, filePath, callback) => {
  * @returns {String}
  */
 const uriDecodeFileName = (opts, fileName) => {
-  return opts.uriDecodeFileNames ? decodeURIComponent(fileName) : fileName;
+  const options = opts || {};
+  if (!options.uriDecodeFileNames) {
+    return fileName;
+  }
+  // Decode file name from URI with checking URI malformed errors.
+  // See Issue https://github.com/richardgirges/express-fileupload/issues/342.
+  try {
+    return decodeURIComponent(fileName);
+  } catch (err) {
+    const matcher = /(%[a-f0-9]{2})/gi;
+    return fileName.split(matcher)
+      .map((str) => {
+        try {
+          return decodeURIComponent(str);
+        } catch (err) {
+          return '';
+        }
+      })
+      .join('');
+  }
 };
 
 /**

--- a/test/utilities.spec.js
+++ b/test/utilities.spec.js
@@ -382,7 +382,8 @@ describe('utilities: Test of the utilities functions', function() {
     const testData = [
       { enc: 'test%22filename', dec: 'test"filename' },
       { enc: 'test%60filename', dec: 'test`filename' },
-      { enc: '%3Fx%3Dtest%22filename', dec: '?x=test"filename'}
+      { enc: '%3Fx%3Dtest%22filename', dec: '?x=test"filename'},
+      { enc: 'bug_bounty_upload_%91%91and%92.txt', dec: 'bug_bounty_upload_and.txt'}
     ];
 
     // Test decoding if uriDecodeFileNames: true.


### PR DESCRIPTION
This PR fixes issue #342.

Unlike PR #343, this fix checks all of the not supported by the decodeURIComponent function characters.

uriDecodeFileName function now doesn't throw error when fileName param contains not supported by the decodeURIComponent characters.

Not supported characters will be removed from the result file name.

