### PR TITLE
Fix issue #259 & some rework and formatting for utilities tests.

### DIFF
--- a/lib/processMultipart.js
+++ b/lib/processMultipart.js
@@ -76,7 +76,10 @@ module.exports = (options, req, res, next) => {
       file.removeAllListeners('data');
       file.resume();
       // After destroy an error event will be emitted and file clean up will be done.
-      file.destroy(new Error(`Upload timeout ${field}->${filename}, bytes:${getFileSize()}`));
+      // In some cases file.destroy() doesn't exist, so we need to check this, see issue:
+      // https://github.com/richardgirges/express-fileupload/issues/259.
+      const err = new Error(`Upload timeout for ${field}->${filename}, bytes:${getFileSize()}`);
+      return isFunc(file.destroy) ? file.destroy(err) : file.emit('error', err);
     });
 
     file.on('limit', () => {

--- a/lib/tempFileHandler.js
+++ b/lib/tempFileHandler.js
@@ -54,7 +54,7 @@ module.exports = (options, fieldname, filename) => {
       completed = true;
       debugLog(options, `Cleaning up temporary file ${tempFilePath}...`);
       writeStream.end();
-      deleteFile(tempFilePath, err => (err 
+      deleteFile(tempFilePath, err => (err
         ? debugLog(options, `Cleaning up temporary file ${tempFilePath} failed: ${err}`)
         : debugLog(options, `Cleaning up temporary file ${tempFilePath} done.`)
       ));

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -230,12 +230,12 @@ const saveBufferToFile = (buffer, filePath, callback) => {
 
 /**
  * Decodes uriEncoded file names.
+ * @param {Object} opts - middleware options.
  * @param fileName {String} - file name to decode.
  * @returns {String}
  */
 const uriDecodeFileName = (opts, fileName) => {
-  const options = opts || {};
-  if (!options.uriDecodeFileNames) {
+  if (!opts || !opts.uriDecodeFileNames) {
     return fileName;
   }
   // Decode file name from URI with checking URI malformed errors.

--- a/lib/utilities.js
+++ b/lib/utilities.js
@@ -185,12 +185,17 @@ const copyFile = (src, dst, callback) => {
  * Firstly trying to rename the file if no luck copying it to dst and then deleteing src.
  * @param {string} src - Path to the source file
  * @param {string} dst - Path to the destination file.
- * @param {Function} callback - A callback function.
+ * @param {Function} callback - A callback function with renamed flag.
  */
-const moveFile = (src, dst, callback) => fs.rename(src, dst, err => (err
-  ? copyFile(src, dst, err => err ? callback(err) : deleteFile(src, callback))
-  : callback()
-));
+const moveFile = (src, dst, callback) => fs.rename(src, dst, (err) => {
+  if (err) {
+    // Try to copy file if rename didn't work.
+    copyFile(src, dst, (cpErr) => (cpErr ? callback(cpErr) : deleteFile(src, callback)));
+    return;
+  }
+  // File was renamed successfully: Add true to the callback to indicate that.
+  callback(null, true);
+});
 
 /**
  * Save buffer data to a file.

--- a/test/server.js
+++ b/test/server.js
@@ -20,8 +20,14 @@ const mockFiles = [
 
 const clearDir = (dir) => {
   try {
-    const stats = fs.statSync(dir);
-    if (stats.isDirectory()) rimraf.sync(dir);
+    try {
+      const stats = fs.statSync(dir);
+      if (stats.isDirectory()) rimraf.sync(dir);
+    } catch (statsErr) {
+      if (statsErr.code !== 'ENOENT') {
+        throw statsErr;
+      }
+    }
     fs.mkdirSync(dir, { recursive: true });
   } catch (err) {
     console.error(err); // eslint-disable-line

--- a/test/server.js
+++ b/test/server.js
@@ -20,10 +20,11 @@ const mockFiles = [
 
 const clearDir = (dir) => {
   try {
-    if (fs.existsSync(dir)) rimraf.sync(dir);
+    const stats = fs.statSync(dir);
+    if (stats.isDirectory()) rimraf.sync(dir);
     fs.mkdirSync(dir, { recursive: true });
   } catch (err) {
-    // 
+    console.error(err); // eslint-disable-line
   }
 };
 

--- a/test/utilities.spec.js
+++ b/test/utilities.spec.js
@@ -17,6 +17,7 @@ const {
   checkAndMakeDir,
   deleteFile,
   copyFile,
+  moveFile,
   saveBufferToFile,
   parseFileName,
   uriDecodeFileName,
@@ -27,11 +28,11 @@ const mockFile = 'basketball.png';
 const mockBuffer = fs.readFileSync(path.join(fileDir, mockFile));
 const mockHash = md5(mockBuffer);
 
+const mockFileMove = 'car.png';
+const mockBufferMove = fs.readFileSync(path.join(fileDir, mockFileMove));
+const mockHashMove = md5(mockBufferMove);
 
 describe('utilities: Test of the utilities functions', function() {
-  beforeEach(function() {
-    server.clearUploadsDir();
-  });
   //debugLog tests
   describe('Test debugLog function', () => {
 
@@ -246,11 +247,43 @@ describe('utilities: Test of the utilities functions', function() {
       assert.equal(checkAndMakeDir({createParentPath: true}, dir), true);
     });
   });
+
+  describe('Test moveFile function', function() {
+    beforeEach(() => server.clearUploadsDir());
+
+    it('Should rename a file and check a hash', function(done) {
+      const srcPath = path.join(fileDir, mockFileMove);
+      const dstPath = path.join(uploadDir, mockFileMove);
+
+      moveFile(srcPath, dstPath, function(err, renamed) {
+        if (err) {
+          return done(err);
+        }
+        fs.stat(dstPath, (err) => {
+          if (err) {
+            return done(err);
+          }
+          // Match source and destination files hash.
+          const fileBuffer = fs.readFileSync(dstPath);
+          const fileHash = md5(fileBuffer);
+          if (fileHash !== mockHashMove) {
+            done(new Error('Hashes do not match'));
+          }
+          // Check that source file was deleted.
+          fs.stat(srcPath, (err) => {
+            if (err) {
+              return done(renamed ? null : new Error('Source file was not renamed'));
+            }
+            done(new Error('Source file was not deleted'));
+          });
+        });
+      });
+    });
+  });
+
   //saveBufferToFile tests
   describe('Test saveBufferToFile function', function(){
-    beforeEach(function() {
-      server.clearUploadsDir();
-    });
+    beforeEach(() => server.clearUploadsDir());
 
     it('Save buffer to a file', function(done) {
       let filePath = path.join(uploadDir, mockFile);
@@ -282,9 +315,7 @@ describe('utilities: Test of the utilities functions', function() {
   });
 
   describe('Test deleteFile function', function(){
-    beforeEach(function() {
-      server.clearUploadsDir();
-    });
+    beforeEach(() => server.clearUploadsDir());
 
     it('Failed if nonexistent file passed', function(done){
       let filePath = path.join(uploadDir, getTempFilename());
@@ -329,9 +360,7 @@ describe('utilities: Test of the utilities functions', function() {
   });
 
   describe('Test copyFile function', function() {
-    beforeEach(function() {
-      server.clearUploadsDir();
-    });
+    beforeEach(() => server.clearUploadsDir());
 
     it('Copy a file and check a hash', function(done) {
       let srcPath = path.join(fileDir, mockFile);

--- a/test/utilities.spec.js
+++ b/test/utilities.spec.js
@@ -299,14 +299,13 @@ describe('utilities: Test of the utilities functions', function() {
     it('Delete a file', function(done){
       let srcPath = path.join(fileDir, mockFile);
       let dstPath = path.join(uploadDir, getTempFilename());
-
-      //copy a file
+      // copy a file
       copyFile(srcPath, dstPath, function(err){
         if (err) {
           return done(err);
         }
         fs.stat(dstPath, (err)=>{
-          if (err){
+          if (err) {
             return done(err);
           }
           // delete a file
@@ -316,11 +315,10 @@ describe('utilities: Test of the utilities functions', function() {
             }
 
             fs.stat(dstPath, (err)=>{
-              if (err){
+              if (err) {
                 return done();
               }
-
-              //error if a file still exist
+              // error if a file still exist
               done(err);
             });
           });
@@ -330,7 +328,7 @@ describe('utilities: Test of the utilities functions', function() {
 
   });
 
-  describe('Test copyFile function', function(){
+  describe('Test copyFile function', function() {
     beforeEach(function() {
       server.clearUploadsDir();
     });


### PR DESCRIPTION
- Checks if `file` instance has `destroy` method to fix issue #259
- Rework utilities tests.
- Fix some typos and formatting.
- Remove deprecated fs.exists from test server.
- Add error logging for cleanDir function in test server.