### PR TITLE
fixed crash when no content-type

### DIFF
--- a/lib/isEligibleRequest.js
+++ b/lib/isEligibleRequest.js
@@ -29,7 +29,7 @@ const hasAcceptableMethod = (req) => !UNACCEPTABLE_METHODS.has(req.method);
  */
 const hasAcceptableContentType = (req) => {
   const contType = req.headers['content-type'];
-  return contType.includes('boundary=') && ACCEPTABLE_CONTENT_TYPE.test(contType);
+  return contType && contType.includes('boundary=') && ACCEPTABLE_CONTENT_TYPE.test(contType);
 };
 
 /**


### PR DESCRIPTION
fixed crash when no content-type
to replicate just make a request like this, and it will crash
curl -v  https://example.com/xxx -d '1' -H 'Content-Type:'